### PR TITLE
Prefer Neovim socket matching project cwd (#1)

### DIFF
--- a/bin/claude-close-diff.sh
+++ b/bin/claude-close-diff.sh
@@ -4,11 +4,12 @@
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-# Read stdin (PostToolUse sends JSON but we don't need it)
-cat > /dev/null
+# Read stdin and extract cwd for socket discovery
+INPUT="$(cat)"
+CWD="$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null || true)"
 
-# Discover Neovim socket and load RPC helpers
-source "$SCRIPT_DIR/nvim-socket.sh" 2>/dev/null
+# Discover Neovim socket (prefer instance whose cwd matches project) and load RPC helpers
+source "$SCRIPT_DIR/nvim-socket.sh" "$CWD" 2>/dev/null
 source "$SCRIPT_DIR/nvim-send.sh"
 
 # Close the diff tab in Neovim (silently skip if no socket)

--- a/bin/claude-preview-diff.sh
+++ b/bin/claude-preview-diff.sh
@@ -13,8 +13,8 @@ INPUT="$(cat)"
 TOOL_NAME="$(echo "$INPUT" | jq -r '.tool_name')"
 CWD="$(echo "$INPUT" | jq -r '.cwd')"
 
-# Discover Neovim socket and load RPC helpers
-source "$SCRIPT_DIR/nvim-socket.sh" 2>/dev/null
+# Discover Neovim socket (prefer instance whose cwd matches project) and load RPC helpers
+source "$SCRIPT_DIR/nvim-socket.sh" "$CWD" 2>/dev/null || true
 source "$SCRIPT_DIR/nvim-send.sh"
 
 HAS_NVIM=true

--- a/bin/nvim-socket.sh
+++ b/bin/nvim-socket.sh
@@ -2,49 +2,107 @@
 # nvim-socket.sh — Discovers the running Neovim's RPC socket path.
 #
 # Usage:
-#   source bin/nvim-socket.sh
+#   source bin/nvim-socket.sh [project_cwd]
 #   echo "$NVIM_SOCKET"
 #
+# If project_cwd is provided, prefers the Neovim instance whose working
+# directory matches (or is a parent of) that path. Falls back to the first
+# valid socket if no CWD match is found.
+#
 # Sets NVIM_SOCKET to the path of a valid, responsive Neovim socket.
-# Returns exit code 1 if no socket is found.
+
+_NVIM_SOCKET_CWD="${1:-}"
+
+# Get the cwd of a process by PID (macOS + Linux compatible)
+_get_pid_cwd() {
+  local pid=$1
+  if [[ -d "/proc/$pid/cwd" ]]; then
+    readlink "/proc/$pid/cwd" 2>/dev/null || true
+  else
+    lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | grep '^n/' | head -1 | cut -c2- || true
+  fi
+}
 
 find_nvim_socket() {
+  # Disable errexit locally — this function is often sourced from scripts
+  # that use set -euo pipefail, and we don't want dead processes or empty
+  # globs to abort execution.
+  local _oldopts
+  _oldopts="$(set +o)"  # save all current set options
+  set +e +o pipefail
+
+  local project_cwd="${1:-}"
+  local result=""
+
   # 1. Check explicit env var first
   if [[ -n "${NVIM_LISTEN_ADDRESS:-}" ]] && [[ -S "$NVIM_LISTEN_ADDRESS" ]]; then
-    echo "$NVIM_LISTEN_ADDRESS"
+    result="$NVIM_LISTEN_ADDRESS"
+    eval "$_oldopts"
+    echo "$result"
     return 0
   fi
 
-  # 2. Scan macOS /var/folders paths (where Neovim puts sockets on macOS)
-  #    Extract PID from socket filename (nvim.<PID>.0) and verify process is alive
+  # Collect all live sockets as "pid:socket_path" entries
+  local live_sockets=()
   local socket pid
-  local sockets
-  sockets=($(compgen -G '/var/folders/*/*/T/nvim.*/*/nvim.*.0' 2>/dev/null)) || true
-  for socket in "${sockets[@]}"; do
-    if [[ -S "$socket" ]]; then
-      pid=$(basename "$socket" | sed 's/^nvim\.\([0-9]*\)\.0$/\1/')
-      if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
-        echo "$socket"
-        return 0
+
+  # 2. Scan macOS /var/folders paths
+  local _glob_out
+  _glob_out="$(compgen -G '/var/folders/*/*/T/nvim.*/*/nvim.*.0' 2>/dev/null)" || true
+  if [[ -n "$_glob_out" ]]; then
+    while IFS= read -r socket; do
+      if [[ -S "$socket" ]]; then
+        pid=$(basename "$socket" | sed 's/^nvim\.\([0-9]*\)\.0$/\1/')
+        if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+          live_sockets+=("$pid:$socket")
+        fi
       fi
-    fi
-  done
+    done <<< "$_glob_out"
+  fi
 
   # 3. Scan /tmp paths (Linux and some macOS setups)
-  local tmp_sockets
-  tmp_sockets=($(compgen -G '/tmp/nvim.*/0' 2>/dev/null)) || true
-  for socket in "${tmp_sockets[@]}"; do
-    if [[ -S "$socket" ]]; then
-      pid=$(echo "$socket" | grep -oE 'nvim\.[0-9]+' | grep -oE '[0-9]+')
-      if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
-        echo "$socket"
-        return 0
+  local _tmp_glob_out
+  _tmp_glob_out="$(compgen -G '/tmp/nvim.*/0' 2>/dev/null)" || true
+  if [[ -n "$_tmp_glob_out" ]]; then
+    while IFS= read -r socket; do
+      if [[ -S "$socket" ]]; then
+        pid=$(echo "$socket" | grep -oE 'nvim\.[0-9]+' | grep -oE '[0-9]+')
+        if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+          live_sockets+=("$pid:$socket")
+        fi
       fi
-    fi
-  done
+    done <<< "$_tmp_glob_out"
+  fi
 
-  return 1
+  if [[ ${#live_sockets[@]} -eq 0 ]]; then
+    eval "$_oldopts"
+    return 1
+  fi
+
+  # 4. If project_cwd given, prefer the socket whose nvim has a matching cwd
+  if [[ -n "$project_cwd" ]]; then
+    local entry nvim_cwd
+    for entry in "${live_sockets[@]}"; do
+      pid="${entry%%:*}"
+      socket="${entry#*:}"
+      nvim_cwd="$(_get_pid_cwd "$pid")"
+      # Check if nvim's cwd matches or is a parent of project_cwd
+      if [[ -n "$nvim_cwd" ]] && [[ "$project_cwd" == "$nvim_cwd" || "$project_cwd" == "$nvim_cwd/"* ]]; then
+        result="$socket"
+        break
+      fi
+    done
+  fi
+
+  # 5. Fallback to the first live socket
+  if [[ -z "$result" ]]; then
+    result="${live_sockets[0]#*:}"
+  fi
+
+  eval "$_oldopts"
+  echo "$result"
+  return 0
 }
 
-NVIM_SOCKET="$(find_nvim_socket || true)"
+NVIM_SOCKET="$(find_nvim_socket "$_NVIM_SOCKET_CWD")" || true
 export NVIM_SOCKET


### PR DESCRIPTION
 ## Problem

  When multiple Neovim instances are running (e.g. tmux with separate nvim + claude-code
   per project), the hook scripts pick the first live socket they find — which may
  belong to a different project. The diff preview opens in the wrong Neovim instance or
  appears to fail silently.

  ## Solution

  Pass the project `cwd` from the hook JSON to `nvim-socket.sh` and prefer the Neovim
  instance whose working directory matches. Falls back to the first live socket if no
  match is found.

  ### Changes

  - **`bin/nvim-socket.sh`** — Rewritten to accept an optional `project_cwd` argument.
  Collects all live sockets, then prefers the one whose Neovim process has a matching
  cwd. Supports both macOS (`lsof`) and Linux (`/proc`) for process cwd lookup.
  - **`bin/claude-close-diff.sh`** — Now parses `cwd` from the PostToolUse hook JSON and
   passes it to socket discovery (previously discarded stdin).
  - **`bin/claude-preview-diff.sh`** — Passes `cwd` to socket discovery.

  Fixes #1
