### PR TITLE
feat: discover Neovim sockets in XDG_RUNTIME_DIR

### DIFF
--- a/bin/nvim-socket.sh
+++ b/bin/nvim-socket.sh
@@ -74,12 +74,31 @@ find_nvim_socket() {
     done <<< "$_tmp_glob_out"
   fi
 
+  # 4. Scan XDG_RUNTIME_DIR paths (NixOS, systemd-based distros)
+  # Complements step 3; on these systems sockets live in $XDG_RUNTIME_DIR, not /tmp
+  local _xdg_dir="${XDG_RUNTIME_DIR:-}"
+  if [[ -z "$_xdg_dir" ]]; then
+    _xdg_dir="/run/user/$(id -u)"
+  fi
+  local _xdg_glob_out
+  _xdg_glob_out="$(compgen -G "$_xdg_dir/nvim.*.0" 2>/dev/null)" || true
+  if [[ -n "$_xdg_glob_out" ]]; then
+    while IFS= read -r socket; do
+      if [[ -S "$socket" ]]; then
+        pid=$(echo "$socket" | grep -oE 'nvim\.[0-9]+' | grep -oE '[0-9]+')
+        if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+          live_sockets+=("$pid:$socket")
+        fi
+      fi
+    done <<< "$_xdg_glob_out"
+  fi
+
   if [[ ${#live_sockets[@]} -eq 0 ]]; then
     eval "$_oldopts"
     return 1
   fi
 
-  # 4. If project_cwd given, prefer the socket whose nvim has a matching cwd
+  # 5. If project_cwd given, prefer the socket whose nvim has a matching cwd
   if [[ -n "$project_cwd" ]]; then
     local entry nvim_cwd
     for entry in "${live_sockets[@]}"; do
@@ -94,7 +113,7 @@ find_nvim_socket() {
     done
   fi
 
-  # 5. Fallback to the first live socket
+  # 6. Fallback to the first live socket
   if [[ -z "$result" ]]; then
     result="${live_sockets[0]#*:}"
   fi


### PR DESCRIPTION
## Summary

- On NixOS and other systemd-based Linux distros, Neovim places its RPC sockets under `$XDG_RUNTIME_DIR` (typically `/run/user/<uid>/`) as `nvim.<pid>.0`, rather than in `/tmp/nvim.<pid>/0`
- Adds a new scan step (step 4) to `bin/nvim-socket.sh` that checks `$XDG_RUNTIME_DIR` for sockets, falling back to `/run/user/$(id -u)` when the env var is unset
- Follows the same pattern as the existing macOS (step 2) and `/tmp` (step 3) scanners — `compgen -G` glob, `while read` loop, `-S` socket check, PID extraction, `kill -0` liveness verification

## Motivation

Without this change, the plugin cannot discover the Neovim socket on NixOS/systemd systems, making `claude-preview-diff.sh` and `claude-close-diff.sh` silently fail to connect.

## Test plan

- [x] Verified on NixOS that sockets at `/run/user/1000/nvim.<pid>.0` are correctly discovered
- [ ] Confirmed no regression on systems where sockets live in `/tmp`
- [ ] When `$XDG_RUNTIME_DIR` is unset, falls back to `/run/user/$(id -u)` gracefully
- [ ] When no sockets exist at the XDG path, the glob returns empty and the step is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)