### PR TITLE
fix: only run checktime if not in command line window

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,16 +206,13 @@ For buffers to auto-reload after Claude writes a file, add this to your Neovim c
 
 ```lua
 vim.o.autoread = true
-  vim.api.nvim_create_autocmd(
-    { "FocusGained", "BufEnter", "CursorHold" },
-    {
-      callback = function()
-        if vim.fn.getcmdwintype() == "" then
-          vim.cmd("checktime")
-        end
-      end,
-    }
-  )
+vim.api.nvim_create_autocmd({ "FocusGained", "BufEnter", "CursorHold" }, {
+ callback = function()
+  if vim.fn.getcmdwintype() == "" then
+   vim.cmd("checktime")
+  end
+ end,
+})
 ```
 
 ---


### PR DESCRIPTION
The `checktime` command reloads buffers that changed on disk. It can't run inside the command-line window (`q:` / `q/`). When `CursorHold` or `FocusGained` fires while you're in that window, Neovim throws E11:
```
Error in CursorHold Autocommands for "*":
E11: Invalid in command-line window; <CR> executes, CTRL-C quits: checktime
```