### PR TITLE
fix: call diffoff before closing diff windows to prevent Neovim crash

### DIFF
--- a/lua/claude-preview/diff.lua
+++ b/lua/claude-preview/diff.lua
@@ -127,6 +127,14 @@ end
 function M.close_diff()
   if diff_tab and vim.api.nvim_tabpage_is_valid(diff_tab) then
     local wins = vim.api.nvim_tabpage_list_wins(diff_tab)
+    -- Turn off diff mode first to avoid triggering DiffUpdated autocmds
+    -- during window close (works around Neovim crash in win_findbuf when
+    -- w_buffer is NULL during frame recalculation)
+    for _, win in ipairs(wins) do
+      if vim.api.nvim_win_is_valid(win) then
+        pcall(vim.api.nvim_win_call, win, function() vim.cmd('diffoff') end)
+      end
+    end
     for _, win in ipairs(wins) do
       if vim.api.nvim_win_is_valid(win) then
         pcall(vim.api.nvim_win_close, win, true)


### PR DESCRIPTION
Works around a NULL dereference in win_findbuf() (neovim/neovim#38353)
where w_buffer can be NULL during frame recalculation when a bufhidden=wipe
buffer is closed. Calling diffoff first prevents DiffUpdated from firing
during the close sequence.
