### PR TITLE
feat: Add GitHub-style inline diff layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # claude-preview.nvim
 
-A Neovim plugin that shows a **side-by-side diff before Claude Code applies any file change** — letting you review exactly what's changing before accepting.
+A Neovim plugin that shows a **diff preview before Claude Code applies any file change** — letting you review exactly what's changing before accepting
 
 Designed for the workflow of running Claude Code CLI in an external terminal alongside Neovim.
 
@@ -31,7 +31,7 @@ Claude CLI (terminal)                                Neovim
 Three mechanisms:
 1. **Claude Code Hooks** — `PreToolUse` intercepts edits, `PostToolUse` cleans up
 2. **Neovim RPC** — hook scripts send Lua commands via `nvim --server <socket> --remote-send`
-3. **Neovim diff mode** — native side-by-side diff in a dedicated tab
+3. **Neovim diff mode** — native side-by-side diff in a dedicated tab, or GitHub-style inline diff
 
 ---
 
@@ -86,24 +86,30 @@ All options with defaults:
 ```lua
 require("claude-preview").setup({
   diff = {
-    layout   = "tab",    -- "tab" (new tab) | "vsplit" (current tab)
+    layout   = "tab",    -- "tab" (new tab) | "vsplit" (current tab) | "inline" (GitHub-style)
     labels   = { current = "CURRENT", proposed = "PROPOSED" },
     auto_close = true,   -- close diff after accept
-    equalize   = true,   -- 50/50 split widths
-    full_file  = true,   -- show full file, not just diff hunks
+    equalize   = true,   -- 50/50 split widths (tab/vsplit only)
+    full_file  = true,   -- show full file, not just diff hunks (tab/vsplit only)
   },
   highlights = {
-    current = {          -- CURRENT (original) side
+    current = {          -- CURRENT (original) side — tab/vsplit layouts
       DiffAdd    = { bg = "#4c2e2e" },
       DiffDelete = { bg = "#4c2e2e" },
       DiffChange = { bg = "#4c3a2e" },
       DiffText   = { bg = "#5c3030" },
     },
-    proposed = {         -- PROPOSED side
+    proposed = {         -- PROPOSED side — tab/vsplit layouts
       DiffAdd    = { bg = "#2e4c2e" },
       DiffDelete = { bg = "#4c2e2e" },
       DiffChange = { bg = "#2e3c4c" },
       DiffText   = { bg = "#3e5c3e" },
+    },
+    inline = {           -- inline layout
+      added        = { bg = "#2e4c2e" },          -- added line background
+      removed      = { bg = "#4c2e2e" },          -- removed line background
+      added_text   = { bg = "#3a6e3a" },          -- changed characters (added)
+      removed_text = { bg = "#6e3a3a" },          -- changed characters (removed)
     },
   },
 })
@@ -126,6 +132,33 @@ require("claude-preview").setup({
 | Key | Description |
 |-----|-------------|
 | `<leader>dq` | Close the diff tab (same as `:ClaudePreviewCloseDiff`) |
+
+---
+
+## Diff Layouts
+
+claude-preview supports three diff layouts, configured via `diff.layout`:
+
+| Layout | Description |
+|--------|-------------|
+| `"tab"` (default) | Side-by-side diff in a new tab — CURRENT on the left, PROPOSED on the right |
+| `"vsplit"` | Side-by-side diff as a vertical split in the current tab |
+| `"inline"` | GitHub-style unified diff in a single buffer with syntax highlighting preserved |
+
+### Inline diff features
+
+- **Syntax highlighting** — the file's language highlighting is preserved
+- **Character-level diffs** — changed portions within a line are highlighted with a brighter background
+- **Sign column** — `+`/`-` signs indicate added/removed lines
+- **Navigation** — `]c` / `[c` to jump between changes
+
+To use inline diff:
+
+```lua
+require("claude-preview").setup({
+  diff = { layout = "inline" },
+})
+```
 
 ---
 

--- a/lua/claude-preview/diff.lua
+++ b/lua/claude-preview/diff.lua
@@ -9,6 +9,7 @@ local diff_augroup = nil
 -- after setup() has merged the user config.
 local current_ns  = vim.api.nvim_create_namespace("claude_diff_current_hl")
 local proposed_ns = vim.api.nvim_create_namespace("claude_diff_proposed_hl")
+local inline_ns   = vim.api.nvim_create_namespace("claude_diff_inline_hl")
 
 local function apply_highlights(config)
   local cur = config.highlights.current
@@ -37,11 +38,249 @@ function M.is_open()
   return diff_tab ~= nil and vim.api.nvim_tabpage_is_valid(diff_tab)
 end
 
+local function apply_inline_highlights(config)
+  local hl = config.highlights.inline or {}
+  vim.api.nvim_set_hl(0, "ClaudeDiffInlineAdded", hl.added or { bg = "#2e4c2e" })
+  vim.api.nvim_set_hl(0, "ClaudeDiffInlineRemoved", hl.removed or { bg = "#4c2e2e" })
+  vim.api.nvim_set_hl(0, "ClaudeDiffInlineAddedText", hl.added_text or { bg = "#3a6e3a" })
+  vim.api.nvim_set_hl(0, "ClaudeDiffInlineRemovedText", hl.removed_text or { bg = "#6e3a3a" })
+  vim.api.nvim_set_hl(0, "ClaudeDiffInlineAddedSign", { fg = "#73e896", bold = true })
+  vim.api.nvim_set_hl(0, "ClaudeDiffInlineRemovedSign", { fg = "#f47070", bold = true })
+  vim.fn.sign_define("ClaudeDiffInlineAddedSign", { text = "+", texthl = "ClaudeDiffInlineAddedSign" })
+  vim.fn.sign_define("ClaudeDiffInlineRemovedSign", { text = "-", texthl = "ClaudeDiffInlineRemovedSign" })
+end
+
+-- Compute character-level diff between two lines, returns list of {start, end} changed ranges
+local function char_diff_ranges(old_line, new_line)
+  -- Find common prefix
+  local prefix = 0
+  local min_len = math.min(#old_line, #new_line)
+  while prefix < min_len and old_line:byte(prefix + 1) == new_line:byte(prefix + 1) do
+    prefix = prefix + 1
+  end
+  -- Find common suffix
+  local suffix = 0
+  while suffix < (min_len - prefix)
+    and old_line:byte(#old_line - suffix) == new_line:byte(#new_line - suffix) do
+    suffix = suffix + 1
+  end
+  -- The changed range in old_line: prefix+1 to #old_line-suffix
+  -- The changed range in new_line: prefix+1 to #new_line-suffix
+  return prefix, #old_line - suffix, #new_line - suffix
+end
+
+local function build_inline_diff(original_path, proposed_path)
+  local orig_lines = read_file_lines(original_path)
+  local prop_lines = read_file_lines(proposed_path)
+  local orig_text = #orig_lines > 0 and (table.concat(orig_lines, "\n") .. "\n") or ""
+  local prop_text = #prop_lines > 0 and (table.concat(prop_lines, "\n") .. "\n") or ""
+
+  local diff_str = vim.diff(orig_text, prop_text, {
+    result_type = "unified",
+    ctxlen = 999999,
+  })
+
+  if not diff_str or diff_str == "" then
+    return prop_lines, {}, {}
+  end
+
+  local display_lines = {}
+  local line_highlights = {}    -- { {line_idx, hl_group} }
+  local char_highlights = {}    -- { {line_idx, hl_group, col_start, col_end} }
+  local signs = {}              -- { {line_idx, sign_name} }
+
+  -- First pass: collect all lines with their types
+  local entries = {}
+  for line in diff_str:gmatch("([^\n]*)\n?") do
+    if line:sub(1, 3) == "---" or line:sub(1, 3) == "+++" then
+      -- skip
+    elseif line:sub(1, 2) == "@@" then
+      -- skip hunk headers — not useful when showing the full file
+    elseif line:sub(1, 1) == "-" then
+      table.insert(entries, { type = "removed", text = line:sub(2) })
+    elseif line:sub(1, 1) == "+" then
+      table.insert(entries, { type = "added", text = line:sub(2) })
+    elseif line ~= "" or #entries > 0 then
+      -- Context lines have a leading space in unified diff
+      local content = line:sub(1, 1) == " " and line:sub(2) or line
+      table.insert(entries, { type = "context", text = content })
+    end
+  end
+
+  -- Second pass: detect removed/added pairs for char-level highlighting
+  local i = 1
+  while i <= #entries do
+    local e = entries[i]
+    if e.type == "removed" then
+      -- Collect consecutive removed lines
+      local removed_start = i
+      while i <= #entries and entries[i].type == "removed" do
+        i = i + 1
+      end
+      local removed_end = i - 1
+      -- Collect consecutive added lines
+      local added_start = i
+      while i <= #entries and entries[i].type == "added" do
+        i = i + 1
+      end
+      local added_end = i - 1
+
+      -- Add removed lines
+      for j = removed_start, removed_end do
+        table.insert(display_lines, entries[j].text)
+        local line_idx = #display_lines - 1
+        table.insert(line_highlights, { line_idx, "ClaudeDiffInlineRemoved" })
+        table.insert(signs, { line_idx, "ClaudeDiffInlineRemovedSign" })
+        -- If there's a matching added line, compute char diff
+        local pair_idx = added_start + (j - removed_start)
+        if pair_idx <= added_end then
+          local old_content = entries[j].text
+          local new_content = entries[pair_idx].text
+          local prefix, old_end, _ = char_diff_ranges(old_content, new_content)
+          if old_end > prefix then
+            table.insert(char_highlights, { line_idx, "ClaudeDiffInlineRemovedText", prefix, old_end })
+          end
+        end
+      end
+      -- Add added lines
+      for j = added_start, added_end do
+        table.insert(display_lines, entries[j].text)
+        local line_idx = #display_lines - 1
+        table.insert(line_highlights, { line_idx, "ClaudeDiffInlineAdded" })
+        table.insert(signs, { line_idx, "ClaudeDiffInlineAddedSign" })
+        -- If there's a matching removed line, compute char diff
+        local pair_idx = removed_start + (j - added_start)
+        if pair_idx <= removed_end then
+          local old_content = entries[pair_idx].text
+          local new_content = entries[j].text
+          local prefix, _, new_end = char_diff_ranges(old_content, new_content)
+          if new_end > prefix then
+            table.insert(char_highlights, { line_idx, "ClaudeDiffInlineAddedText", prefix, new_end })
+          end
+        end
+      end
+    else
+      table.insert(display_lines, e.text)
+      local line_idx = #display_lines - 1
+      if e.type == "added" then
+        table.insert(line_highlights, { line_idx, "ClaudeDiffInlineAdded" })
+        table.insert(signs, { line_idx, "ClaudeDiffInlineAddedSign" })
+      elseif e.type == "removed" then
+        table.insert(line_highlights, { line_idx, "ClaudeDiffInlineRemoved" })
+        table.insert(signs, { line_idx, "ClaudeDiffInlineRemovedSign" })
+      end
+      i = i + 1
+    end
+  end
+
+  return display_lines, line_highlights, char_highlights, signs
+end
+
+local function show_inline_diff(original_path, proposed_path, real_file_path, cfg)
+  apply_inline_highlights(cfg)
+
+  local display_name = real_file_path or "unknown"
+  local ft = vim.filetype.match({ filename = real_file_path }) or ""
+  local display_lines, line_highlights, char_highlights, signs =
+    build_inline_diff(original_path, proposed_path)
+
+  vim.cmd("tabnew")
+  diff_tab = vim.api.nvim_get_current_tabpage()
+
+  local buf = vim.api.nvim_get_current_buf()
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, display_lines)
+
+  vim.bo[buf].buftype    = "nofile"
+  vim.bo[buf].bufhidden  = "wipe"
+  vim.bo[buf].swapfile   = false
+  vim.bo[buf].modifiable = false
+  if ft ~= "" then vim.bo[buf].filetype = ft end
+
+  -- Apply full-line highlights
+  for _, hl in ipairs(line_highlights) do
+    local line_len = #(display_lines[hl[1] + 1] or "")
+    vim.api.nvim_buf_set_extmark(buf, inline_ns, hl[1], 0, {
+      end_col = line_len,
+      hl_group = hl[2],
+      hl_eol = true,
+      priority = 150,
+    })
+  end
+  -- Apply character-level highlights on top
+  for _, hl in ipairs(char_highlights) do
+    vim.api.nvim_buf_set_extmark(buf, inline_ns, hl[1], hl[3], {
+      end_col = hl[4],
+      hl_group = hl[2],
+      priority = 200,
+    })
+  end
+  -- Place signs for +/- indicators
+  for _, s in ipairs(signs) do
+    vim.fn.sign_place(0, "ClaudeDiffInlineSigns", s[2], buf, { lnum = s[1] + 1 })
+  end
+
+  local win = vim.api.nvim_get_current_win()
+  vim.wo[win].winbar = "%#DiagnosticInfo# INLINE DIFF %* " .. display_name
+  vim.wo[win].number = true
+  vim.wo[win].wrap = false
+  vim.wo[win].cursorline = true
+  vim.wo[win].signcolumn = "yes"
+
+  diff_bufs = { buf }
+
+  -- Track sign group for cleanup
+  local sign_group = "ClaudeDiffInlineSigns"
+
+  -- Find first changed line for navigation
+  local first_change_line = nil
+  if #signs > 0 then
+    first_change_line = signs[1][1]
+  end
+
+  -- Change navigation keymaps (using sign positions)
+  local change_lines = {}
+  for _, s in ipairs(signs) do
+    change_lines[s[1] + 1] = true
+  end
+
+  vim.keymap.set("n", "]c", function()
+    local cur = vim.api.nvim_win_get_cursor(0)[1]
+    for lnum = cur + 1, vim.api.nvim_buf_line_count(buf) do
+      if change_lines[lnum] then
+        vim.api.nvim_win_set_cursor(0, { lnum, 0 })
+        return
+      end
+    end
+  end, { buffer = buf, desc = "Next change" })
+
+  vim.keymap.set("n", "[c", function()
+    local cur = vim.api.nvim_win_get_cursor(0)[1]
+    for lnum = cur - 1, 1, -1 do
+      if change_lines[lnum] then
+        vim.api.nvim_win_set_cursor(0, { lnum, 0 })
+        return
+      end
+    end
+  end, { buffer = buf, desc = "Previous change" })
+
+  -- Jump to first change
+  if first_change_line then
+    vim.api.nvim_win_set_cursor(win, { first_change_line + 1, 0 })
+  end
+end
+
 function M.show_diff(original_path, proposed_path, real_file_path)
   -- Close any existing diff first
   M.close_diff()
 
   local cfg = require("claude-preview").config
+
+  -- Inline layout: single-buffer unified diff
+  if cfg.diff.layout == "inline" then
+    show_inline_diff(original_path, proposed_path, real_file_path, cfg)
+    return
+  end
+
   apply_highlights(cfg)
 
   local display_name = real_file_path or "unknown"

--- a/lua/claude-preview/init.lua
+++ b/lua/claude-preview/init.lua
@@ -5,7 +5,7 @@ M.config = {}
 
 local default_config = {
   diff = {
-    layout = "tab",        -- "tab" or "vsplit"
+    layout = "tab",        -- "tab", "vsplit", or "inline"
     labels = { current = "CURRENT", proposed = "PROPOSED" },
     auto_close = true,
     equalize = true,
@@ -38,6 +38,12 @@ local default_config = {
       DiffDelete = { bg = "#4c2e2e" },
       DiffChange = { bg = "#2e3c4c" },
       DiffText   = { bg = "#3e5c3e" },
+    },
+    inline = {
+      added        = { bg = "#2e4c2e" },
+      removed      = { bg = "#4c2e2e" },
+      added_text   = { bg = "#3a6e3a" },
+      removed_text = { bg = "#6e3a3a" },
     },
   },
 }


### PR DESCRIPTION
## Summary

- Add a new `layout = "inline"` option that renders diffs in a single buffer instead of two side-by-side panes
- Preserves the file's syntax highlighting (treesitter) while overlaying diff indicators
- Character-level highlighting shows exactly what changed within a line
- `+`/`-` signs in the sign column indicate added/removed lines
- `]c` / `[c` keymaps for navigating between changes
- Fully configurable highlight colors via `highlights.inline` config

## Diff Layouts

| Layout | Description |
|--------|-------------|
| `"tab"` (default) | Side-by-side diff in a new tab |
| `"vsplit"` | Side-by-side diff in current tab |
| `"inline"` (new) | GitHub-style unified diff in a single buffer |

## Usage

```lua
require("claude-preview").setup({
  diff = { layout = "inline" },
})
```

## Test plan

- [x] Inline diff renders with syntax highlighting preserved
- [x] Character-level highlights show changed portions within modified lines
- [x] `+`/`-` signs appear in sign column for added/removed lines
- [x] `]c` / `[c` navigation between changes works
- [x] `close_diff()` and `<leader>dq` cleanup works correctly
- [x] Neo-tree integration works alongside inline layout
- [x] No regression on existing `tab` and `vsplit` layouts

## Screenshot:

<img width="1470" height="888" alt="Screenshot 2026-03-26 at 7 56 24 PM" src="https://github.com/user-attachments/assets/598589d0-0be4-48f3-8333-542f802ffd03" />

## Fixes: 
#8 

