### PR TITLE
fix: guard PostToolUse cleanup behind is_open() check

### DIFF
--- a/bin/claude-close-diff.sh
+++ b/bin/claude-close-diff.sh
@@ -24,9 +24,15 @@ fi
 DIFF_OPEN=$(nvim --server "$NVIM_SOCKET" --remote-expr "luaeval(\"require('claude-preview.diff').is_open()\")" 2>/dev/null || echo "false")
 
 if [[ "$DIFF_OPEN" == "true" ]]; then
+  FILE_PATH="$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null || true)"
   nvim_send "require('claude-preview.changes').clear_all()" || true
   nvim_send "require('claude-preview.diff').close_diff()" || true
-  nvim_send "vim.defer_fn(function() pcall(function() require('claude-preview.neo_tree').refresh() end) end, 200)" || true
+  if [[ -n "$FILE_PATH" ]]; then
+    FILE_PATH_ESC="$(escape_lua "$FILE_PATH")"
+    nvim_send "vim.defer_fn(function() pcall(function() require('claude-preview.neo_tree').refresh() end) vim.defer_fn(function() pcall(function() require('claude-preview.neo_tree').reveal('$FILE_PATH_ESC') end) end, 200) end, 200)" || true
+  else
+    nvim_send "vim.defer_fn(function() pcall(function() require('claude-preview.neo_tree').refresh() end) end, 200)" || true
+  fi
 fi
 
 # Clean up temp files


### PR DESCRIPTION
## Problem

The close-diff hook runs `clear_all()`, `close_diff()`, and neo-tree `refresh()` on every PostToolUse event — even when no diff tab is open. This causes neo-tree to pop open unexpectedly after unrelated tool calls.

## Fix

Check `is_open()` before running any cleanup. Also drops the post-close `reveal()` call, which could trigger CWD-mismatch prompts for files outside the project tree.

## Test plan

- [x] Run an Edit tool call, accept it — diff tab closes normally
- [x] Run a Bash tool call with no prior diff — neo-tree stays unchanged
- [x] `rm` detection via Bash still clears deletion markers