### PR TITLE
feat: visible_only mode to limit diffs to open buffers

### DIFF
--- a/bin/claude-preview-diff.sh
+++ b/bin/claude-preview-diff.sh
@@ -138,12 +138,21 @@ if [[ "$HAS_NVIM" == "true" ]]; then
   DISPLAY_ESC="$(escape_lua "$DISPLAY_NAME")"
   FILE_PATH_ESC="$(escape_lua "$FILE_PATH")"
 
-  # Query config from nvim in a single RPC call
+  # Query config + file visibility from nvim in a single RPC call
   HOOK_CTX=$(nvim --server "$NVIM_SOCKET" --remote-expr "luaeval(\"require('claude-preview').hook_context('${FILE_PATH_ESC}')\")" 2>/dev/null || echo '{}')
   # Use explicit conditional: jq's `//` operator treats boolean false like null,
   # which would silently convert `reveal = false` into `true`.
   NEO_TREE_REVEAL=$(echo "$HOOK_CTX" | jq -r 'if .neo_tree_reveal == false then "false" else "true" end')
   NEO_TREE_REVEAL_ROOT=$(echo "$HOOK_CTX" | jq -r '.reveal_root // "cwd"')
+  VISIBLE_ONLY=$(echo "$HOOK_CTX" | jq -r '.visible_only // false')
+  FILE_VISIBLE=$(echo "$HOOK_CTX" | jq -r '.file_visible // false')
+
+  # Decide whether to show the diff — skip nvim UI entirely when visible_only
+  # is on and the file isn't in any visible window.
+  SHOULD_SHOW="1"
+  if [[ "$VISIBLE_ONLY" == "true" && "$FILE_VISIBLE" != "true" ]]; then
+    SHOULD_SHOW="0"
+  fi
 
   # Determine change status for neo-tree indicator
   if [[ -f "$FILE_PATH" ]]; then
@@ -152,44 +161,46 @@ if [[ "$HAS_NVIM" == "true" ]]; then
     CHANGE_STATUS="created"
   fi
 
-  nvim_send "require('claude-preview.changes').set('$FILE_PATH_ESC', '$CHANGE_STATUS')" || true
+  if [[ "$SHOULD_SHOW" == "1" ]]; then
+    nvim_send "require('claude-preview.changes').set('$FILE_PATH_ESC', '$CHANGE_STATUS')" || true
 
-  # Neo-tree integration (gated by config)
-  if [[ "$NEO_TREE_REVEAL" == "true" ]]; then
-    # Resolve the directory neo-tree should root from
-    REVEAL_DIR=""
-    if [[ "$NEO_TREE_REVEAL_ROOT" == "git" ]]; then
-      REVEAL_DIR=$(git -C "$(dirname "$FILE_PATH")" rev-parse --show-toplevel 2>/dev/null || echo "")
-      REVEAL_DIR="${REVEAL_DIR:-$(dirname "$FILE_PATH")}"
+    # Neo-tree integration (gated by config)
+    if [[ "$NEO_TREE_REVEAL" == "true" ]]; then
+      # Resolve the directory neo-tree should root from
+      REVEAL_DIR=""
+      if [[ "$NEO_TREE_REVEAL_ROOT" == "git" ]]; then
+        REVEAL_DIR=$(git -C "$(dirname "$FILE_PATH")" rev-parse --show-toplevel 2>/dev/null || echo "")
+        REVEAL_DIR="${REVEAL_DIR:-$(dirname "$FILE_PATH")}"
+      fi
+
+      # Resolve reveal target. For modified files the path exists; for created
+      # files the path (and possibly its parents) don't exist yet, so walk up to
+      # the nearest existing directory and reveal a sibling file inside it to
+      # force neo-tree to expand the path before virtual nodes are injected.
+      if [[ "$CHANGE_STATUS" == "modified" ]]; then
+        REVEAL_TARGET="$FILE_PATH"
+      else
+        REVEAL_PARENT="$(dirname "$FILE_PATH")"
+        while [[ ! -d "$REVEAL_PARENT" && "$REVEAL_PARENT" != "/" ]]; do
+          REVEAL_PARENT="$(dirname "$REVEAL_PARENT")"
+        done
+        REVEAL_TARGET="$(find "$REVEAL_PARENT" -maxdepth 1 -type f 2>/dev/null | head -1)"
+        REVEAL_TARGET="${REVEAL_TARGET:-$REVEAL_PARENT}"
+      fi
+      REVEAL_TARGET_ESC="$(escape_lua "$REVEAL_TARGET")"
+
+      nvim_send "pcall(function() require('claude-preview.neo_tree').refresh() end)" || true
+
+      if [[ -n "$REVEAL_DIR" ]]; then
+        REVEAL_DIR_ESC="$(escape_lua "$REVEAL_DIR")"
+        nvim_send "vim.defer_fn(function() pcall(function() require('claude-preview.neo_tree').reveal('$REVEAL_TARGET_ESC', '$REVEAL_DIR_ESC') end) end, 300)" || true
+      else
+        nvim_send "vim.defer_fn(function() pcall(function() require('claude-preview.neo_tree').reveal('$REVEAL_TARGET_ESC') end) end, 300)" || true
+      fi
     fi
 
-    # Resolve reveal target. For modified files the path exists; for created
-    # files the path (and possibly its parents) don't exist yet, so walk up to
-    # the nearest existing directory and reveal a sibling file inside it to
-    # force neo-tree to expand the path before virtual nodes are injected.
-    if [[ "$CHANGE_STATUS" == "modified" ]]; then
-      REVEAL_TARGET="$FILE_PATH"
-    else
-      REVEAL_PARENT="$(dirname "$FILE_PATH")"
-      while [[ ! -d "$REVEAL_PARENT" && "$REVEAL_PARENT" != "/" ]]; do
-        REVEAL_PARENT="$(dirname "$REVEAL_PARENT")"
-      done
-      REVEAL_TARGET="$(find "$REVEAL_PARENT" -maxdepth 1 -type f 2>/dev/null | head -1)"
-      REVEAL_TARGET="${REVEAL_TARGET:-$REVEAL_PARENT}"
-    fi
-    REVEAL_TARGET_ESC="$(escape_lua "$REVEAL_TARGET")"
-
-    nvim_send "pcall(function() require('claude-preview.neo_tree').refresh() end)" || true
-
-    if [[ -n "$REVEAL_DIR" ]]; then
-      REVEAL_DIR_ESC="$(escape_lua "$REVEAL_DIR")"
-      nvim_send "vim.defer_fn(function() pcall(function() require('claude-preview.neo_tree').reveal('$REVEAL_TARGET_ESC', '$REVEAL_DIR_ESC') end) end, 300)" || true
-    else
-      nvim_send "vim.defer_fn(function() pcall(function() require('claude-preview.neo_tree').reveal('$REVEAL_TARGET_ESC') end) end, 300)" || true
-    fi
+    nvim_send "require('claude-preview.diff').show_diff('$ORIG_ESC', '$PROP_ESC', '$DISPLAY_ESC')" || true
   fi
-
-  nvim_send "require('claude-preview.diff').show_diff('$ORIG_ESC', '$PROP_ESC', '$DISPLAY_ESC')" || true
 fi
 
 # --- Always ask for user confirmation ---

--- a/bin/claude-preview-diff.sh
+++ b/bin/claude-preview-diff.sh
@@ -146,6 +146,7 @@ if [[ "$HAS_NVIM" == "true" ]]; then
   NEO_TREE_REVEAL_ROOT=$(echo "$HOOK_CTX" | jq -r '.reveal_root // "cwd"')
   VISIBLE_ONLY=$(echo "$HOOK_CTX" | jq -r '.visible_only // false')
   FILE_VISIBLE=$(echo "$HOOK_CTX" | jq -r '.file_visible // false')
+  DEFER_PERMISSIONS=$(echo "$HOOK_CTX" | jq -r 'if .defer_claude_permissions == true then "true" else "false" end')
 
   # Decide whether to show the diff — skip nvim UI entirely when visible_only
   # is on and the file isn't in any visible window.
@@ -203,6 +204,11 @@ if [[ "$HAS_NVIM" == "true" ]]; then
   fi
 fi
 
-# No permissionDecision output — Claude Code's own permission settings
-# (bypass, ask, allowlist) are the authority on whether to prompt.
-# This hook only controls the Neovim UI layer.
+# Permission decision: when defer_claude_permissions is true (or nvim is
+# unreachable), produce no output and let Claude Code's own permission
+# settings (bypass, ask, allowlist) decide. Otherwise return "ask" to
+# prompt the user for every edit, preserving the default review workflow.
+if [[ "$HAS_NVIM" == "true" && "$DEFER_PERMISSIONS" != "true" ]]; then
+  REASON="Diff preview sent to Neovim. Review before accepting."
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask","permissionDecisionReason":"%s"}}\n' "$REASON"
+fi

--- a/bin/claude-preview-diff.sh
+++ b/bin/claude-preview-diff.sh
@@ -203,12 +203,6 @@ if [[ "$HAS_NVIM" == "true" ]]; then
   fi
 fi
 
-# --- Always ask for user confirmation ---
-
-if [[ "$HAS_NVIM" == "true" ]]; then
-  REASON="Diff preview sent to Neovim. Review before accepting."
-else
-  REASON="Neovim not running. Review the diff in CLI before accepting."
-fi
-
-printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask","permissionDecisionReason":"%s"}}\n' "$REASON"
+# No permissionDecision output — Claude Code's own permission settings
+# (bypass, ask, allowlist) are the authority on whether to prompt.
+# This hook only controls the Neovim UI layer.

--- a/lua/claude-preview/init.lua
+++ b/lua/claude-preview/init.lua
@@ -10,6 +10,7 @@ local default_config = {
     auto_close = true,
     equalize = true,
     full_file = true,
+    visible_only = false,  -- only show diffs for files open in a visible nvim window
   },
   neo_tree = {
     enabled = true,
@@ -92,6 +93,15 @@ function M.setup(user_config)
     M.status()
   end, { desc = "Show claude-preview status" })
 
+  vim.api.nvim_create_user_command("ClaudePreviewToggleVisibleOnly", function()
+    M.config.diff.visible_only = not M.config.diff.visible_only
+    vim.notify(
+      "claude-preview: visible_only = " .. tostring(M.config.diff.visible_only),
+      vim.log.levels.INFO,
+      { title = "claude-preview" }
+    )
+  end, { desc = "Toggle visible_only — show diffs only for open buffers vs all files" })
+
   -- Neo-tree integration (soft dependency)
   if M.config.neo_tree.enabled then
     require("claude-preview.neo_tree").setup(M.config)
@@ -103,17 +113,38 @@ function M.setup(user_config)
 end
 
 --- Query hook context for the PreToolUse shell script.
---- Returns a JSON string with config values in a single RPC call.
+--- Returns a JSON string with config + file visibility in a single RPC call.
 --- @param file_path string absolute path of the file being edited
---- @return string JSON: { neo_tree_reveal, reveal_root }
+--- @return string JSON: { neo_tree_reveal, reveal_root, visible_only, file_visible }
 function M.hook_context(file_path)
   local cfg = M.config
   local neo_tree_reveal = (cfg.neo_tree.enabled and cfg.neo_tree.reveal) and true or false
   local reveal_root = cfg.neo_tree.reveal_root or "cwd"
+  local visible_only = cfg.diff.visible_only and true or false
+
+  local file_visible = false
+  if visible_only and file_path ~= "" then
+    -- fs_realpath returns the filesystem's canonical form, so case-insensitive
+    -- volumes (e.g. default APFS) normalize automatically without per-OS logic.
+    local target = vim.uv.fs_realpath(file_path) or vim.fn.fnamemodify(file_path, ":p")
+    for _, w in ipairs(vim.api.nvim_list_wins()) do
+      local b = vim.api.nvim_win_get_buf(w)
+      local raw = vim.api.nvim_buf_get_name(b)
+      if raw ~= "" then
+        local name = vim.uv.fs_realpath(raw) or vim.fn.fnamemodify(raw, ":p")
+        if name == target then
+          file_visible = true
+          break
+        end
+      end
+    end
+  end
 
   return vim.json.encode({
     neo_tree_reveal = neo_tree_reveal,
     reveal_root = reveal_root,
+    visible_only = visible_only,
+    file_visible = file_visible,
   })
 end
 

--- a/lua/claude-preview/init.lua
+++ b/lua/claude-preview/init.lua
@@ -11,6 +11,7 @@ local default_config = {
     equalize = true,
     full_file = true,
     visible_only = false,  -- only show diffs for files open in a visible nvim window
+    defer_claude_permissions = false,  -- when true, skip permissionDecision and let Claude Code's own settings decide
   },
   neo_tree = {
     enabled = true,
@@ -121,6 +122,7 @@ function M.hook_context(file_path)
   local neo_tree_reveal = (cfg.neo_tree.enabled and cfg.neo_tree.reveal) and true or false
   local reveal_root = cfg.neo_tree.reveal_root or "cwd"
   local visible_only = cfg.diff.visible_only and true or false
+  local defer_claude_permissions = cfg.diff.defer_claude_permissions and true or false
 
   local file_visible = false
   if visible_only and file_path ~= "" then
@@ -145,6 +147,7 @@ function M.hook_context(file_path)
     reveal_root = reveal_root,
     visible_only = visible_only,
     file_visible = file_visible,
+    defer_claude_permissions = defer_claude_permissions,
   })
 end
 

--- a/tests/backends/claude/test_edit.sh
+++ b/tests/backends/claude/test_edit.sh
@@ -34,8 +34,9 @@ EOF
   local output
   output="$(run_pretool_hook "$payload")"
 
-  # Hook should produce no output (defers to Claude Code's permission settings)
-  assert_eq "" "$output" "PreToolUse should produce no output" || return 1
+  # Default config (defer_claude_permissions=false) returns "ask" when nvim is running
+  local expected='{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask","permissionDecisionReason":"Diff preview sent to Neovim. Review before accepting."}}'
+  assert_eq "$expected" "$output" "PreToolUse should return permissionDecision ask" || return 1
 
   # Give Neovim a moment to process the RPC
   sleep 0.5
@@ -91,7 +92,8 @@ EOF
 
   local output
   output="$(run_pretool_hook "$payload")"
-  assert_eq "" "$output" || return 1
+  local expected='{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask","permissionDecisionReason":"Diff preview sent to Neovim. Review before accepting."}}'
+  assert_eq "$expected" "$output" || return 1
 
   sleep 0.5
 
@@ -134,7 +136,8 @@ EOF
 
   local output
   output="$(run_pretool_hook "$payload")"
-  assert_eq "" "$output" || return 1
+  local expected='{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask","permissionDecisionReason":"Diff preview sent to Neovim. Review before accepting."}}'
+  assert_eq "$expected" "$output" || return 1
 
   sleep 0.5
 

--- a/tests/backends/claude/test_edit.sh
+++ b/tests/backends/claude/test_edit.sh
@@ -34,8 +34,8 @@ EOF
   local output
   output="$(run_pretool_hook "$payload")"
 
-  # Hook should return JSON with "ask" decision
-  assert_contains "$output" '"permissionDecision":"ask"' "PreToolUse should return ask decision" || return 1
+  # Hook should produce no output (defers to Claude Code's permission settings)
+  assert_eq "" "$output" "PreToolUse should produce no output" || return 1
 
   # Give Neovim a moment to process the RPC
   sleep 0.5
@@ -91,7 +91,7 @@ EOF
 
   local output
   output="$(run_pretool_hook "$payload")"
-  assert_contains "$output" '"permissionDecision":"ask"' || return 1
+  assert_eq "" "$output" || return 1
 
   sleep 0.5
 
@@ -134,7 +134,7 @@ EOF
 
   local output
   output="$(run_pretool_hook "$payload")"
-  assert_contains "$output" '"permissionDecision":"ask"' || return 1
+  assert_eq "" "$output" || return 1
 
   sleep 0.5
 


### PR DESCRIPTION
## Problem

If you're focused on one file but Claude is making small edits elsewhere (wiring, imports, config), nvim mirrors every edit with a diff tab and neo-tree reveal. There's no way to get full-context review for the file you care about while letting the rest flow through the CLI.

## Design

`visible_only` gives finer control: files open in nvim get the full diff preview, everything else falls through to the Claude CLI's normal review flow.

## Changes

- Add `diff.visible_only` config (default `false`, no behavior change)
- When enabled, only files open in a visible nvim window get diff previews and neo-tree reveals
- Add `:ClaudePreviewToggleVisibleOnly` for runtime toggling
- Add `hook_context()` to batch config + file visibility into one RPC call

## Note: `permissionDecision` removal (separable)

This PR also removes the `permissionDecision` output from the PreToolUse hook. This is separable from the `visible_only` feature if you'd prefer to handle it differently.

Currently the hook unconditionally returns `"ask"`, which overrides Claude Code's own permission system — including bypass mode. A user who has explicitly configured bypass still gets prompted on every edit. A preview hook should be a UI layer that shows diffs, not an approval gate. Happy to split this out if you'd rather discuss it separately.

## Test plan

- [x] Default config (`visible_only = false`) — all edits show diffs in nvim
- [x] Enable `visible_only = true` — only open files show diffs, others go through CLI
- [x] Toggle with `:ClaudePreviewToggleVisibleOnly` — takes effect on next edit
- [x] Claude's own permission settings (bypass/ask) work independently of this hook