### PR TITLE
test: fix stale-socket e2e tests to exercise scan-based discovery

### DIFF
--- a/tests/backends/claude/test_stale_socket.sh
+++ b/tests/backends/claude/test_stale_socket.sh
@@ -11,8 +11,12 @@ setup_test_project
 # ── Test: Hook works after Neovim restart ────────────────────────
 
 test_stale_socket_recovery() {
-  # Start first Neovim instance
-  start_nvim
+  # Start the first Neovim instance on a scanner-compatible socket path. The
+  # hook still has to rediscover it by filesystem scan because scan mode clears
+  # NVIM_LISTEN_ADDRESS before invoking the hook.
+  start_nvim_on_socket "$TEST_PROJECT_DIR"
+  local first_socket="$TEST_SOCKET"
+  local first_pid="$NVIM_PID"
 
   local test_file
   test_file="$(create_test_file "src/recover.lua" 'local old = true')"
@@ -32,22 +36,34 @@ test_stale_socket_recovery() {
 EOF
 )
 
-  run_pretool_hook "$payload" >/dev/null
+  run_pretool_hook "$payload" scan >/dev/null
   sleep 0.5
   local is_open
   is_open="$(nvim_eval "require('claude-preview.diff').is_open()")"
   assert_eq "true" "$is_open" "diff should open on first instance" || return 1
 
-  run_posttool_hook "$payload" >/dev/null
+  run_posttool_hook "$payload" scan >/dev/null
   sleep 0.3
 
-  # Kill Neovim (simulates user quitting)
-  stop_nvim
+  # Kill Neovim without cleaning the socket, simulating a stale socket entry.
+  crash_nvim
+  assert_file_exists "$first_socket" "old socket should remain on disk after crash" || return 1
+  if kill -0 "$first_pid" 2>/dev/null; then
+    echo "  FAIL: stale Neovim PID should be dead" >&2
+    return 1
+  fi
 
-  # Start a fresh Neovim instance (same socket path since we control it)
-  start_nvim
+  # Start a fresh Neovim instance. Each launch uses a PID-derived socket path,
+  # so the new socket will differ from the crashed one.
+  start_nvim_on_socket "$TEST_PROJECT_DIR"
+  local second_socket="$TEST_SOCKET"
+  if [[ "$first_socket" == "$second_socket" ]]; then
+    echo "  FAIL: restart should use a different socket path" >&2
+    return 1
+  fi
 
-  # The hook should work with the new instance
+  # The hook should rediscover the live socket by scanning, not by trusting a
+  # fixed environment variable.
   local payload2
   payload2=$(cat <<EOF
 {
@@ -62,25 +78,31 @@ EOF
 EOF
 )
 
-  run_pretool_hook "$payload2" >/dev/null
+  run_pretool_hook "$payload2" scan >/dev/null
   sleep 0.5
 
   local is_open2
   is_open2="$(nvim_eval "require('claude-preview.diff').is_open()")"
   assert_eq "true" "$is_open2" "diff should open on second (restarted) instance" || return 1
 
-  run_posttool_hook "$payload2" >/dev/null
+  run_posttool_hook "$payload2" scan >/dev/null
   sleep 0.3
 }
 
-# ── Test: Hook script handles missing Neovim gracefully ──────────
+# ── Test: Hook exits cleanly without a guaranteed project match ──
 
-test_no_nvim_graceful() {
-  # Simulate no running Neovim instance by pointing socket discovery at
-  # a bogus address and preventing the scan from finding real instances
-  # (override PATH so nvim-socket.sh's compgen/ls can't find real sockets)
+test_no_matching_project_nvim_graceful() {
+  # Ensure no test Neovim is running before this test. The payload cwd points
+  # at a nonexistent project, so there is no guaranteed matching test instance.
+  # The scanner may still fall back to an unrelated ambient nvim, and this test
+  # intentionally does not assert socket absence.
+  stop_nvim
+
   local test_file
   test_file="$(create_test_file "src/noserver.lua" 'print("hi")')"
+
+  local hook_tmpdir
+  hook_tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/claude-test-no-nvim-tmp.XXXXXX")"
 
   local payload
   payload=$(cat <<EOF
@@ -96,50 +118,29 @@ test_no_nvim_graceful() {
 EOF
 )
 
-  # Create a minimal script that wraps the hook with an isolated environment:
-  # - NVIM_LISTEN_ADDRESS points to a nonexistent socket
-  # - We override find_nvim_socket to always fail by using a wrapper script
-  local wrapper
-  wrapper="$(mktemp /tmp/claude-test-no-nvim.XXXXXX.sh)"
-  cat > "$wrapper" <<WRAPPER
-#!/usr/bin/env bash
-set -euo pipefail
-# Override nvim-socket.sh: make it always fail to find a socket
-export NVIM_LISTEN_ADDRESS="/tmp/bogus-nvim-socket-$$"
-export NVIM_SOCKET=""
+  # Force scan mode by blanking any inherited NVIM_LISTEN_ADDRESS. The hook
+  # must still compute the proposed file and exit cleanly even if there is no
+  # project-specific Neovim to attach to.
+  local exit_code=0
+  echo "$payload" | \
+    NVIM_LISTEN_ADDRESS= \
+    TMPDIR="$hook_tmpdir" \
+    bash "$REPO_ROOT/bin/claude-preview-diff.sh" >/dev/null 2>&1 || exit_code=$?
 
-SCRIPT_DIR="$REPO_ROOT/bin"
-# Source nvim-send.sh for helpers but skip socket discovery
-source "\$SCRIPT_DIR/nvim-send.sh"
+  # The hook exits 0 on non-crash paths, including when it cannot identify a
+  # project-specific nvim instance.
+  assert_eq "0" "$exit_code" "hook must exit 0 without a guaranteed project nvim match" || return 1
 
-# Read stdin and process like claude-preview-diff.sh but with no socket
-INPUT="\$(cat)"
-TOOL_NAME="\$(echo "\$INPUT" | jq -r '.tool_name')"
-
-# The actual diff script — source it with our overrides
-exec bash "$REPO_ROOT/bin/claude-preview-diff.sh"
-WRAPPER
-  chmod +x "$wrapper"
-
-  # Run with empty NVIM_LISTEN_ADDRESS pointing to nonexistent socket
-  local output
-  output="$(echo "$payload" | \
-    NVIM_LISTEN_ADDRESS="/tmp/bogus-nvim-socket-$$" \
-    bash "$REPO_ROOT/bin/claude-preview-diff.sh" 2>/dev/null || true)"
-  rm -f "$wrapper"
-
-  # Should produce a valid JSON response with "ask" decision
-  assert_contains "$output" '"permissionDecision":"ask"' "should still return ask decision without Neovim" || return 1
-  # The script should still compute the edit and produce output (just can't send to Neovim)
-  # The proposed temp file should exist
-  local proposed="${TMPDIR:-/tmp}/claude-diff-proposed"
-  assert_file_exists "$proposed" "proposed file should be computed even without Neovim" || return 1
+  # The proposed temp file must exist: headless nvim computed the edit.
+  local proposed="$hook_tmpdir/claude-diff-proposed"
+  assert_file_exists "$proposed" "proposed file should be computed even without a project-specific nvim match" || return 1
+  rm -rf "$hook_tmpdir"
 }
 
 # ── Run all tests ────────────────────────────────────────────────
 
 run_test "Hook works after Neovim restart (stale socket)" test_stale_socket_recovery
-run_test "Hook handles missing Neovim gracefully" test_no_nvim_graceful
+run_test "Hook exits cleanly without a guaranteed project match" test_no_matching_project_nvim_graceful
 
 # ── Teardown ─────────────────────────────────────────────────────
 

--- a/tests/helpers.sh
+++ b/tests/helpers.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 # ── Paths ────────────────────────────────────────────────────────
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-TEST_SOCKET="/tmp/claude-preview-test-nvim.sock"
+TEST_SOCKET="${TMPDIR:-/tmp}/claude-preview-test-nvim.sock"
 TEST_PROJECT_DIR=""
 NVIM_PID=""
 
@@ -40,6 +40,10 @@ TESTS_TOTAL=0
 setup_test_project() {
   TEST_PROJECT_DIR="$(mktemp -d /tmp/claude-preview-test-project.XXXXXX)"
   mkdir -p "$TEST_PROJECT_DIR"
+  # Resolve symlinks so the path matches what lsof reports for nvim's cwd.
+  # On macOS /tmp is a symlink to /private/tmp; without this the CWD-preference
+  # logic in find_nvim_socket would never match the test instance.
+  TEST_PROJECT_DIR="$(cd "$TEST_PROJECT_DIR" && pwd -P)"
 }
 
 cleanup_test_project() {
@@ -63,33 +67,69 @@ create_test_file() {
 # ── Neovim lifecycle ─────────────────────────────────────────────
 
 start_nvim() {
-  # Clean up any leftover socket
-  rm -f "$TEST_SOCKET"
+  start_nvim_on_socket "$PWD"
+}
 
-  # Start headless Neovim with the plugin in the runtime path
-  # Use --clean to avoid user config interference
-  nvim --headless --clean \
-    --cmd "set rtp+=$REPO_ROOT" \
-    --listen "$TEST_SOCKET" \
-    -c "lua require('claude-preview').setup()" \
-    &>/dev/null &
+# start_nvim_on_socket [nvim_cwd]
+#
+# Start a headless Neovim on a scanner-compatible socket path. We launch nvim
+# via a tiny wrapper shell so the child PID is baked into `/tmp/nvim.<pid>/0`,
+# which is one of the exact paths that bin/nvim-socket.sh scans in production.
+# This keeps scan-mode tests deterministic even on platforms where headless
+# nvim does not auto-create a discoverable socket on its own. Sets TEST_SOCKET
+# to the discovered path and NVIM_PID to the pid.
+start_nvim_on_socket() {
+  local nvim_cwd="${1:-$PWD}"
+
+  # Start headless Neovim with the plugin in the runtime path on a socket the
+  # production scanner can rediscover by PID.
+  bash -c '
+    nvim_cwd="$1"
+    repo_root="$2"
+    listen="/tmp/nvim.$$/0"
+    mkdir -p "${listen%/*}"
+    exec nvim --headless --clean --listen "$listen" \
+      --cmd "cd $nvim_cwd" \
+      --cmd "set rtp+=$repo_root" \
+      -c "lua require('\''claude-preview'\'').setup()"
+  ' _ "$nvim_cwd" "$REPO_ROOT" &>/dev/null &
   NVIM_PID=$!
+  TEST_SOCKET="/tmp/nvim.${NVIM_PID}/0"
 
-  # Wait for socket to appear (up to 5 seconds)
+  # Poll for the scanner-compatible socket path we asked nvim to create. If a
+  # different nested /tmp path appears, fail loudly because the production
+  # scanner would never rediscover it.
+  local unsupported=""
   local tries=0
-  while [[ ! -S "$TEST_SOCKET" ]] && (( tries < 50 )); do
+  while [[ ! -S "$TEST_SOCKET" && -z "$unsupported" ]] && (( tries < 50 )); do
     sleep 0.1
     tries=$((tries + 1))
+    unsupported=$(
+      compgen -G "/tmp/nvim.*/*/nvim.${NVIM_PID}.0" 2>/dev/null \
+        | head -1 || true
+    )
+    [[ -n "$unsupported" && ! -S "$unsupported" ]] && unsupported=""
   done
 
+  if [[ -n "$unsupported" ]]; then
+    echo -e "${RED}FATAL: Neovim auto-socket path is unsupported by bin/nvim-socket.sh: $unsupported${NC}" >&2
+    kill "$NVIM_PID" 2>/dev/null || true
+    NVIM_PID=""
+    return 1
+  fi
+
   if [[ ! -S "$TEST_SOCKET" ]]; then
-    echo -e "${RED}FATAL: Neovim failed to start (socket not created)${NC}" >&2
+    echo -e "${RED}FATAL: Neovim failed to start (scanner-compatible socket not found for PID $NVIM_PID at $TEST_SOCKET)${NC}" >&2
+    kill "$NVIM_PID" 2>/dev/null || true
+    NVIM_PID=""
     return 1
   fi
 
   # Verify it responds
   if ! nvim --server "$TEST_SOCKET" --remote-expr "1" >/dev/null 2>&1; then
-    echo -e "${RED}FATAL: Neovim started but socket not responsive${NC}" >&2
+    echo -e "${RED}FATAL: Neovim started but socket not responsive: $TEST_SOCKET${NC}" >&2
+    kill -9 "$NVIM_PID" 2>/dev/null || true
+    NVIM_PID=""
     return 1
   fi
 }
@@ -103,6 +143,15 @@ stop_nvim() {
     kill -0 "$NVIM_PID" 2>/dev/null && kill -9 "$NVIM_PID" 2>/dev/null || true
   fi
   rm -f "$TEST_SOCKET"
+  NVIM_PID=""
+}
+
+crash_nvim() {
+  if [[ -n "$NVIM_PID" ]] && kill -0 "$NVIM_PID" 2>/dev/null; then
+    kill -9 "$NVIM_PID" 2>/dev/null || true
+    wait "$NVIM_PID" 2>/dev/null || true
+    sleep 0.2
+  fi
   NVIM_PID=""
 }
 
@@ -185,7 +234,7 @@ assert_not_contains() {
 assert_file_exists() {
   local path="$1"
   local msg="${2:-"expected file to exist: $path"}"
-  if [[ ! -f "$path" ]]; then
+  if [[ ! -e "$path" ]]; then
     echo -e "  ${RED}FAIL: $msg${NC}" >&2
     return 1
   fi
@@ -194,7 +243,7 @@ assert_file_exists() {
 assert_file_not_exists() {
   local path="$1"
   local msg="${2:-"expected file NOT to exist: $path"}"
-  if [[ -f "$path" ]]; then
+  if [[ -e "$path" ]]; then
     echo -e "  ${RED}FAIL: $msg${NC}" >&2
     return 1
   fi
@@ -235,15 +284,31 @@ print_summary() {
 # redirect to /dev/null if you don't need the output.
 run_pretool_hook() {
   local json_payload="$1"
-  echo "$json_payload" | \
-    NVIM_LISTEN_ADDRESS="$TEST_SOCKET" \
-    bash "$REPO_ROOT/bin/claude-preview-diff.sh" 2>/dev/null || true
+  local mode="${2:-socket}"
+
+  if [[ "$mode" == "scan" ]]; then
+    echo "$json_payload" | \
+      NVIM_LISTEN_ADDRESS= \
+      bash "$REPO_ROOT/bin/claude-preview-diff.sh" 2>/dev/null || true
+  else
+    echo "$json_payload" | \
+      NVIM_LISTEN_ADDRESS="$TEST_SOCKET" \
+      bash "$REPO_ROOT/bin/claude-preview-diff.sh" 2>/dev/null || true
+  fi
 }
 
 # Run the PostToolUse hook script with a JSON payload
 run_posttool_hook() {
   local json_payload="$1"
-  echo "$json_payload" | \
-    NVIM_LISTEN_ADDRESS="$TEST_SOCKET" \
-    bash "$REPO_ROOT/bin/claude-close-diff.sh" 2>/dev/null || true
+  local mode="${2:-socket}"
+
+  if [[ "$mode" == "scan" ]]; then
+    echo "$json_payload" | \
+      NVIM_LISTEN_ADDRESS= \
+      bash "$REPO_ROOT/bin/claude-close-diff.sh" 2>/dev/null || true
+  else
+    echo "$json_payload" | \
+      NVIM_LISTEN_ADDRESS="$TEST_SOCKET" \
+      bash "$REPO_ROOT/bin/claude-close-diff.sh" 2>/dev/null || true
+  fi
 }


### PR DESCRIPTION
Fixes #26.

Two structural bugs in the e2e stale-socket tests prevented them from exercising what they claimed. See issue #26 for details.

**Changes (tests only, no `bin/` or `lua/` changes):**

1. `test_stale_socket_recovery` now genuinely exercises scan-based socket discovery. Starts nvim on `--listen "/tmp/nvim.$$/0"` (a path `bin/nvim-socket.sh` recognizes via its `/tmp/nvim.*/0` glob), crashes it with `kill -9` leaving a stale socket, starts a second nvim, verifies the hook rediscovers via the scan.
2. Adds opt-in `scan` mode to `run_pretool_hook`/`run_posttool_hook` that explicitly clears `NVIM_LISTEN_ADDRESS=` to force the slow path.
3. Renames `test_no_nvim_graceful` to `test_no_matching_project_nvim_graceful` and rewrites it to assert only what the body proves (clean exit + proposed file generation). Genuine isolation from ambient nvim instances would require invasive environment changes, so the test is scoped to honest claims.
4. Small corrections: `assert_file_exists` changed from `[[ ! -f ]]` to `[[ ! -e ]]` because unix domain sockets fail `-f`. `setup_test_project` now canonicalizes `TEST_PROJECT_DIR` with `pwd -P` to handle macOS's `/tmp` → `/private/tmp` symlink, which otherwise breaks the CWD-preference matching in `find_nvim_socket`.

**Verified locally**: 14/14 tests pass on macOS (nvim 0.11).

**CI portability**: `/tmp/nvim.<pid>/0` is in the production scanner's glob set and works cross-platform. The `pwd -P` fix is macOS-specific and a no-op on Linux.
