### PR TITLE
feat: multi-tab simultaneous diffs for multi-file edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,6 @@ require("code-preview").setup({
   diff = {
     layout   = "tab",    -- "tab" (new tab) | "vsplit" (current tab) | "inline" (GitHub-style)
     labels   = { current = "CURRENT", proposed = "PROPOSED" },
-    auto_close = true,   -- close diff after accept
     equalize   = true,   -- 50/50 split widths (tab/vsplit only)
     full_file  = true,   -- show full file, not just diff hunks (tab/vsplit only)
     visible_only = false, -- skip diffs for files not open in any Neovim buffer

--- a/bin/apply-edit.lua
+++ b/bin/apply-edit.lua
@@ -26,8 +26,8 @@ if replace_all then
   local result = {}
   local search_start = 1
   if old_string == "" then
-    -- Nothing to replace; write content unchanged
-    result = { content }
+    -- Empty old_string: prepend new_string (handles "insert into empty file")
+    result = { new_string, content }
   else
     while true do
       local s, e = string.find(content, old_string, search_start, true)
@@ -43,7 +43,10 @@ if replace_all then
   content = table.concat(result)
 else
   -- Replace first occurrence only
-  if old_string ~= "" then
+  if old_string == "" then
+    -- Empty old_string: prepend new_string (handles "insert into empty file")
+    content = new_string .. content
+  else
     local s, e = string.find(content, old_string, 1, true)
     if s then
       content = content:sub(1, s - 1) .. new_string .. content:sub(e + 1)

--- a/bin/core-post-tool.sh
+++ b/bin/core-post-tool.sh
@@ -33,22 +33,14 @@ fi
 FILE_PATH="$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null || true)"
 FILE_PATH_ESC="$(escape_lua "${FILE_PATH:-}")"
 
-# Only clean up if a diff for THIS file is actually open.
-# OpenCode fires all before-hooks before any after-hooks, so the open diff
-# may belong to a different file — closing it would kill the wrong preview.
-DIFF_OPEN=$(nvim --server "$NVIM_SOCKET" --remote-expr "luaeval(\"require('code-preview.diff').is_open('${FILE_PATH_ESC}')\")" 2>/dev/null || echo "false")
-
-if [[ "$DIFF_OPEN" == "true" ]]; then
-  nvim_send "require('code-preview.changes').clear_all()" || true
-  nvim_send "require('code-preview.diff').close_diff()" || true
-  if [[ -n "$FILE_PATH" ]]; then
-    nvim_send "vim.defer_fn(function() pcall(function() require('code-preview.neo_tree').refresh() end) vim.defer_fn(function() pcall(function() require('code-preview.neo_tree').reveal('$FILE_PATH_ESC') end) end, 200) end, 200)" || true
-  else
-    nvim_send "vim.defer_fn(function() pcall(function() require('code-preview.neo_tree').refresh() end) end, 200)" || true
-  fi
+# Tell Lua to handle this file's close — tolerates out-of-order post-hooks
+# (OpenCode may fire them in a different order than pre-hooks).
+if [[ -n "$FILE_PATH" ]]; then
+  nvim_send "require('code-preview.diff').close_for_file('$FILE_PATH_ESC')" || true
+  # neo_tree.refresh() is handled inside close_for_file() via vim.schedule()
 fi
 
-# Clean up temp files
-rm -f "${TMPDIR:-/tmp}/claude-diff-original" "${TMPDIR:-/tmp}/claude-diff-proposed"
+# Clean up temp files (both legacy shared paths and per-PID paths)
+rm -f "${TMPDIR:-/tmp}"/claude-diff-original* "${TMPDIR:-/tmp}"/claude-diff-proposed*
 
 exit 0

--- a/bin/core-pre-tool.sh
+++ b/bin/core-pre-tool.sh
@@ -32,8 +32,12 @@ if [[ -z "${NVIM_SOCKET:-}" ]]; then
 fi
 
 TMPDIR="${TMPDIR:-/tmp}"
-ORIG_FILE="$TMPDIR/claude-diff-original"
-PROP_FILE="$TMPDIR/claude-diff-proposed"
+# Use unique temp files per hook invocation so rapid-fire pre-hooks
+# (OpenCode fires all before-hooks before any after-hooks) don't clobber
+# each other's diff content.
+HOOK_ID="$$"
+ORIG_FILE="$TMPDIR/claude-diff-original-$HOOK_ID"
+PROP_FILE="$TMPDIR/claude-diff-proposed-$HOOK_ID"
 
 # --- Compute original and proposed file content ---
 
@@ -50,7 +54,7 @@ case "$TOOL_NAME" in
       > "$ORIG_FILE"
     fi
 
-    NVIM_LISTEN_ADDRESS= nvim --headless -l "$SCRIPT_DIR/apply-edit.lua" "$FILE_PATH" "$OLD_STRING" "$NEW_STRING" "$REPLACE_ALL" "$PROP_FILE"
+    NVIM_LISTEN_ADDRESS= nvim --headless -l "$SCRIPT_DIR/apply-edit.lua" "$FILE_PATH" "$OLD_STRING" "$NEW_STRING" "$REPLACE_ALL" "$PROP_FILE" || true
     ;;
 
   Write)
@@ -152,12 +156,10 @@ if [[ "$HAS_NVIM" == "true" ]]; then
   DISPLAY_ESC="$(escape_lua "$DISPLAY_NAME")"
   FILE_PATH_ESC="$(escape_lua "$FILE_PATH")"
 
-  # Query config + file visibility from nvim in a single RPC call
+  # Query config + file visibility from nvim in a single RPC call.
+  # Neo-tree indicator/reveal is now driven from lua/code-preview/diff.lua
+  # (inside show_diff), so we only need visibility + permission fields here.
   HOOK_CTX=$(nvim --server "$NVIM_SOCKET" --remote-expr "luaeval(\"require('code-preview').hook_context('${FILE_PATH_ESC}')\")" 2>/dev/null || echo '{}')
-  # Use explicit conditional: jq's `//` operator treats boolean false like null,
-  # which would silently convert `reveal = false` into `true`.
-  NEO_TREE_REVEAL=$(echo "$HOOK_CTX" | jq -r 'if .neo_tree_reveal == false then "false" else "true" end')
-  NEO_TREE_REVEAL_ROOT=$(echo "$HOOK_CTX" | jq -r '.reveal_root // "cwd"')
   VISIBLE_ONLY=$(echo "$HOOK_CTX" | jq -r '.visible_only // false')
   FILE_VISIBLE=$(echo "$HOOK_CTX" | jq -r '.file_visible // false')
   DEFER_PERMISSIONS=$(echo "$HOOK_CTX" | jq -r 'if .defer_claude_permissions == true then "true" else "false" end')
@@ -169,51 +171,7 @@ if [[ "$HAS_NVIM" == "true" ]]; then
     SHOULD_SHOW="0"
   fi
 
-  # Determine change status for neo-tree indicator
-  if [[ -f "$FILE_PATH" ]]; then
-    CHANGE_STATUS="modified"
-  else
-    CHANGE_STATUS="created"
-  fi
-
   if [[ "$SHOULD_SHOW" == "1" ]]; then
-    nvim_send "require('code-preview.changes').set('$FILE_PATH_ESC', '$CHANGE_STATUS')" || true
-
-    # Neo-tree integration (gated by config)
-    if [[ "$NEO_TREE_REVEAL" == "true" ]]; then
-      # Resolve the directory neo-tree should root from
-      REVEAL_DIR=""
-      if [[ "$NEO_TREE_REVEAL_ROOT" == "git" ]]; then
-        REVEAL_DIR=$(git -C "$(dirname "$FILE_PATH")" rev-parse --show-toplevel 2>/dev/null || echo "")
-        REVEAL_DIR="${REVEAL_DIR:-$(dirname "$FILE_PATH")}"
-      fi
-
-      # Resolve reveal target. For modified files the path exists; for created
-      # files the path (and possibly its parents) don't exist yet, so walk up to
-      # the nearest existing directory and reveal a sibling file inside it to
-      # force neo-tree to expand the path before virtual nodes are injected.
-      if [[ "$CHANGE_STATUS" == "modified" ]]; then
-        REVEAL_TARGET="$FILE_PATH"
-      else
-        REVEAL_PARENT="$(dirname "$FILE_PATH")"
-        while [[ ! -d "$REVEAL_PARENT" && "$REVEAL_PARENT" != "/" ]]; do
-          REVEAL_PARENT="$(dirname "$REVEAL_PARENT")"
-        done
-        REVEAL_TARGET="$(find "$REVEAL_PARENT" -maxdepth 1 -type f 2>/dev/null | head -1)"
-        REVEAL_TARGET="${REVEAL_TARGET:-$REVEAL_PARENT}"
-      fi
-      REVEAL_TARGET_ESC="$(escape_lua "$REVEAL_TARGET")"
-
-      nvim_send "pcall(function() require('code-preview.neo_tree').refresh() end)" || true
-
-      if [[ -n "$REVEAL_DIR" ]]; then
-        REVEAL_DIR_ESC="$(escape_lua "$REVEAL_DIR")"
-        nvim_send "vim.defer_fn(function() pcall(function() require('code-preview.neo_tree').reveal('$REVEAL_TARGET_ESC', '$REVEAL_DIR_ESC') end) end, 300)" || true
-      else
-        nvim_send "vim.defer_fn(function() pcall(function() require('code-preview.neo_tree').reveal('$REVEAL_TARGET_ESC') end) end, 300)" || true
-      fi
-    fi
-
     nvim_send "require('code-preview.diff').show_diff('$ORIG_ESC', '$PROP_ESC', '$DISPLAY_ESC', '$FILE_PATH_ESC')" || true
   fi
 fi

--- a/lua/code-preview/diff.lua
+++ b/lua/code-preview/diff.lua
@@ -1,14 +1,12 @@
 local M = {}
 
--- Track the diff tab so we can close it later
-local diff_tab = nil
-local diff_bufs = {}
-local diff_augroup = nil
-local diff_file_path = nil  -- tag: which file this diff belongs to
+-- Active diffs keyed by absolute file path.
+-- Each entry: { tab, bufs, augroup, inline_win }
+local active_diffs = {}
 
--- Queue for pending diffs (OpenCode fires all before-hooks before any after-hooks,
--- so we queue subsequent diffs and show them as each one is closed).
-local diff_queue = {}
+-- Per-buffer inline diff state (line numbers, types) for statuscolumn.
+-- Keyed by buffer handle.
+local buf_inline_data = {}
 
 -- Namespaces created at module load, but colors applied inside show_diff()
 -- after setup() has merged the user config.
@@ -27,6 +25,49 @@ local function apply_highlights(config)
   end
 end
 
+-- Update neo-tree indicator + reveal for a file that's about to be previewed.
+local function mark_change_and_reveal(abs_file_path)
+  if not abs_file_path or abs_file_path == "" then
+    return
+  end
+
+  local status = vim.loop.fs_stat(abs_file_path) and "modified" or "created"
+  pcall(function() require("code-preview.changes").set(abs_file_path, status) end)
+  pcall(function() require("code-preview.neo_tree").refresh() end)
+
+  local cfg = require("code-preview").config
+  if not (cfg and cfg.neo_tree and cfg.neo_tree.reveal ~= false) then
+    return
+  end
+
+  local reveal_dir = nil
+  if cfg.neo_tree.reveal_root == "git" then
+    local parent = vim.fn.fnamemodify(abs_file_path, ":h")
+    local git_out = vim.fn.systemlist(
+      "git -C " .. vim.fn.shellescape(parent) .. " rev-parse --show-toplevel 2>/dev/null"
+    )
+    if vim.v.shell_error == 0 and git_out[1] and git_out[1] ~= "" then
+      reveal_dir = git_out[1]
+    end
+  end
+
+  local reveal_target = abs_file_path
+  if status == "created" then
+    local parent = vim.fn.fnamemodify(abs_file_path, ":h")
+    while parent ~= "/" and vim.fn.isdirectory(parent) == 0 do
+      parent = vim.fn.fnamemodify(parent, ":h")
+    end
+    local siblings = vim.fn.glob(parent .. "/*", false, true)
+    reveal_target = siblings[1] or parent
+  end
+
+  vim.defer_fn(function()
+    pcall(function()
+      require("code-preview.neo_tree").reveal(reveal_target, reveal_dir)
+    end)
+  end, 300)
+end
+
 local function read_file_lines(path)
   local lines = {}
   local f = io.open(path, "r")
@@ -39,42 +80,46 @@ local function read_file_lines(path)
   return lines
 end
 
-function M.is_open(file_path)
-  if diff_tab == nil or not vim.api.nvim_tabpage_is_valid(diff_tab) then
-    return false
-  end
-  -- If a file_path is given, only return true if the diff is for that file
-  if file_path and file_path ~= "" and diff_file_path and diff_file_path ~= file_path then
-    return false
-  end
-  return true
+--- Count how many active diffs are currently open.
+local function active_count()
+  local n = 0
+  for _ in pairs(active_diffs) do n = n + 1 end
+  return n
 end
 
--- Module-level storage for inline diff line numbers
-local inline_line_numbers = {}
+function M.is_open(file_path)
+  if file_path and file_path ~= "" then
+    local entry = active_diffs[file_path]
+    if entry and entry.tab and vim.api.nvim_tabpage_is_valid(entry.tab) then
+      return true
+    end
+    return false
+  end
+  -- No file_path: return true if ANY diff is open
+  return active_count() > 0
+end
 
--- Module-level storage for inline diff line types
-local inline_line_types = {}
-
--- Track which window is the inline diff window
-local inline_diff_win = nil
-
--- Statuscolumn function for inline diff: shows old|new line numbers + sign
+-- Statuscolumn function for inline diff: shows old|new line numbers + sign.
+-- Reads per-buffer state from buf_inline_data so multiple inline diffs coexist.
 function M.inline_statuscolumn(col_width)
-  -- Only apply to the inline diff window
-  if vim.g.statusline_winid ~= inline_diff_win then
+  local win = vim.g.statusline_winid
+  local buf = vim.api.nvim_win_get_buf(win)
+  local data = buf_inline_data[buf]
+  if not data then
     return ""
   end
   local lnum = vim.v.lnum
-  if not inline_line_numbers[lnum] then
+  local line_numbers = data.line_numbers
+  local line_types = data.line_types
+  if not line_numbers[lnum] then
     return string.rep(" ", col_width * 2 + 3)
   end
-  local old_num = inline_line_numbers[lnum][1]
-  local new_num = inline_line_numbers[lnum][2]
+  local old_num = line_numbers[lnum][1]
+  local new_num = line_numbers[lnum][2]
   local old_str = old_num and string.format("%" .. col_width .. "d", old_num) or string.rep(" ", col_width)
   local new_str = new_num and string.format("%" .. col_width .. "d", new_num) or string.rep(" ", col_width)
 
-  local line_type = inline_line_types[lnum]
+  local line_type = line_types[lnum]
   local sign = " "
   if line_type == "added" then
     sign = "%#ClaudeDiffInlineAddedSign#+%*"
@@ -97,20 +142,16 @@ end
 
 -- Compute character-level diff between two lines, returns list of {start, end} changed ranges
 local function char_diff_ranges(old_line, new_line)
-  -- Find common prefix
   local prefix = 0
   local min_len = math.min(#old_line, #new_line)
   while prefix < min_len and old_line:byte(prefix + 1) == new_line:byte(prefix + 1) do
     prefix = prefix + 1
   end
-  -- Find common suffix
   local suffix = 0
   while suffix < (min_len - prefix)
     and old_line:byte(#old_line - suffix) == new_line:byte(#new_line - suffix) do
     suffix = suffix + 1
   end
-  -- The changed range in old_line: prefix+1 to #old_line-suffix
-  -- The changed range in new_line: prefix+1 to #new_line-suffix
   return prefix, #old_line - suffix, #new_line - suffix
 end
 
@@ -130,50 +171,44 @@ local function build_inline_diff(original_path, proposed_path)
   end
 
   local display_lines = {}
-  local line_highlights = {}    -- { {line_idx, hl_group} }
-  local char_highlights = {}    -- { {line_idx, hl_group, col_start, col_end} }
-  local line_numbers = {}       -- { {old_num|nil, new_num|nil} } per display line
-  local line_types = {}         -- { [lnum] = "added"|"removed"|nil } per display line
+  local line_highlights = {}
+  local char_highlights = {}
+  local line_numbers = {}
+  local line_types = {}
 
-  -- First pass: collect all lines with their types
   local entries = {}
   for line in diff_str:gmatch("([^\n]*)\n?") do
     if line:sub(1, 3) == "---" or line:sub(1, 3) == "+++" then
       -- skip
     elseif line:sub(1, 2) == "@@" then
-      -- skip hunk headers — not useful when showing the full file
+      -- skip hunk headers
     elseif line:sub(1, 1) == "-" then
       table.insert(entries, { type = "removed", text = line:sub(2) })
     elseif line:sub(1, 1) == "+" then
       table.insert(entries, { type = "added", text = line:sub(2) })
     elseif line ~= "" or #entries > 0 then
-      -- Context lines have a leading space in unified diff
       local content = line:sub(1, 1) == " " and line:sub(2) or line
       table.insert(entries, { type = "context", text = content })
     end
   end
 
-  -- Second pass: detect removed/added pairs for char-level highlighting
   local old_num = 0
   local new_num = 0
   local i = 1
   while i <= #entries do
     local e = entries[i]
     if e.type == "removed" then
-      -- Collect consecutive removed lines
       local removed_start = i
       while i <= #entries and entries[i].type == "removed" do
         i = i + 1
       end
       local removed_end = i - 1
-      -- Collect consecutive added lines
       local added_start = i
       while i <= #entries and entries[i].type == "added" do
         i = i + 1
       end
       local added_end = i - 1
 
-      -- Add removed lines
       for j = removed_start, removed_end do
         table.insert(display_lines, entries[j].text)
         local line_idx = #display_lines - 1
@@ -181,18 +216,16 @@ local function build_inline_diff(original_path, proposed_path)
         table.insert(line_numbers, { old_num, nil })
         table.insert(line_highlights, { line_idx, "ClaudeDiffInlineRemoved" })
         line_types[line_idx + 1] = "removed"
-        -- If there's a matching added line, compute char diff
         local pair_idx = added_start + (j - removed_start)
         if pair_idx <= added_end then
           local old_content = entries[j].text
           local new_content = entries[pair_idx].text
-          local prefix, old_end, _ = char_diff_ranges(old_content, new_content)
-          if old_end > prefix then
-            table.insert(char_highlights, { line_idx, "ClaudeDiffInlineRemovedText", prefix, old_end })
+          local pfx, old_end, _ = char_diff_ranges(old_content, new_content)
+          if old_end > pfx then
+            table.insert(char_highlights, { line_idx, "ClaudeDiffInlineRemovedText", pfx, old_end })
           end
         end
       end
-      -- Add added lines
       for j = added_start, added_end do
         table.insert(display_lines, entries[j].text)
         local line_idx = #display_lines - 1
@@ -200,14 +233,13 @@ local function build_inline_diff(original_path, proposed_path)
         table.insert(line_numbers, { nil, new_num })
         table.insert(line_highlights, { line_idx, "ClaudeDiffInlineAdded" })
         line_types[line_idx + 1] = "added"
-        -- If there's a matching removed line, compute char diff
         local pair_idx = removed_start + (j - added_start)
         if pair_idx <= removed_end then
           local old_content = entries[pair_idx].text
           local new_content = entries[j].text
-          local prefix, _, new_end = char_diff_ranges(old_content, new_content)
-          if new_end > prefix then
-            table.insert(char_highlights, { line_idx, "ClaudeDiffInlineAddedText", prefix, new_end })
+          local pfx, _, new_end = char_diff_ranges(old_content, new_content)
+          if new_end > pfx then
+            table.insert(char_highlights, { line_idx, "ClaudeDiffInlineAddedText", pfx, new_end })
           end
         end
       end
@@ -236,6 +268,7 @@ local function build_inline_diff(original_path, proposed_path)
   return display_lines, line_highlights, char_highlights, line_numbers, line_types
 end
 
+--- Create an inline diff tab and return {tab, bufs, inline_win}.
 local function show_inline_diff(original_path, proposed_path, real_file_path, cfg)
   apply_inline_highlights(cfg)
 
@@ -245,8 +278,7 @@ local function show_inline_diff(original_path, proposed_path, real_file_path, cf
     build_inline_diff(original_path, proposed_path)
 
   vim.cmd("tabnew")
-  diff_tab = vim.api.nvim_get_current_tabpage()
-
+  local tab = vim.api.nvim_get_current_tabpage()
   local buf = vim.api.nvim_get_current_buf()
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, display_lines)
 
@@ -274,29 +306,33 @@ local function show_inline_diff(original_path, proposed_path, real_file_path, cf
       priority = 200,
     })
   end
-  local win = vim.api.nvim_get_current_win()
-  -- Store line numbers, types, and buffer for statuscolumn to access
-  inline_line_numbers = line_numbers
-  inline_line_types = line_types
-  inline_diff_win = win
 
-  -- Determine column width based on max line number
+  local win = vim.api.nvim_get_current_win()
+
+  -- Store per-buffer inline data for statuscolumn
+  buf_inline_data[buf] = {
+    line_numbers = line_numbers,
+    line_types = line_types,
+  }
+
   local max_num = 0
   for _, nums in ipairs(line_numbers) do
     if nums[1] and nums[1] > max_num then max_num = nums[1] end
     if nums[2] and nums[2] > max_num then max_num = nums[2] end
   end
-  local col_width = #tostring(max_num)
+  local col_width = math.max(#tostring(max_num), 1)
 
-  vim.wo[win].winbar = "%#DiagnosticInfo# INLINE DIFF %* " .. display_name
+  local n = active_count()
+  local winbar_prefix = n > 0
+    and string.format("%%#DiagnosticInfo# DIFF [%d pending] %%* ", n + 1)
+    or "%#DiagnosticInfo# INLINE DIFF %* "
+  vim.wo[win].winbar = winbar_prefix .. display_name
   vim.wo[win].number = false
   vim.wo[win].relativenumber = false
   vim.wo[win].wrap = false
   vim.wo[win].cursorline = true
   vim.wo[win].signcolumn = "no"
   vim.wo[win].statuscolumn = "%!v:lua.require('code-preview.diff').inline_statuscolumn(" .. col_width .. ")"
-
-  diff_bufs = { buf }
 
   -- Find first changed line for navigation
   local first_change_line = nil
@@ -326,67 +362,49 @@ local function show_inline_diff(original_path, proposed_path, real_file_path, cf
     end
   end, { buffer = buf, desc = "Previous change" })
 
-  -- Jump to first change
   if first_change_line then
     vim.api.nvim_win_set_cursor(win, { first_change_line, 0 })
   end
+
+  return { tab = tab, bufs = { buf }, inline_win = win }
 end
 
 function M.show_diff(original_path, proposed_path, real_file_path, abs_file_path)
-  -- If a diff is already open for a DIFFERENT file, queue this one instead
-  -- of replacing it. OpenCode fires all before-hooks before any after-hooks,
-  -- so without queuing the user would only see the last file's diff.
-  if M.is_open() and abs_file_path and diff_file_path ~= abs_file_path then
-    -- Snapshot the temp file contents now — they'll be overwritten by the
-    -- next hook call. We read them into memory so the queued diff survives.
-    local orig_lines = {}
-    local prop_lines = {}
-    local f = io.open(original_path, "r")
-    if f then for l in f:lines() do orig_lines[#orig_lines + 1] = l end; f:close() end
-    f = io.open(proposed_path, "r")
-    if f then for l in f:lines() do prop_lines[#prop_lines + 1] = l end; f:close() end
-    table.insert(diff_queue, {
-      orig_lines = orig_lines,
-      prop_lines = prop_lines,
-      real_file_path = real_file_path,
-      abs_file_path = abs_file_path,
-    })
-    return
+  local file_key = abs_file_path or real_file_path
+  -- If a diff for this SAME file is already open, close it first (re-edit)
+  if file_key and active_diffs[file_key] then
+    M.close_for_file(file_key)
   end
 
-  -- Close any existing diff first
-  M.close_diff()
-
-  -- Tag this diff with the absolute file path it belongs to.
-  -- abs_file_path is the full path used by post-tool to check is_open();
-  -- real_file_path is the display name shown in the winbar.
-  diff_file_path = abs_file_path or real_file_path
+  -- Set the neo-tree indicator + reveal
+  mark_change_and_reveal(abs_file_path)
 
   local cfg = require("code-preview").config
 
-  -- Inline layout: single-buffer unified diff
+  -- Inline layout
   if cfg.diff.layout == "inline" then
-    show_inline_diff(original_path, proposed_path, real_file_path, cfg)
+    local result = show_inline_diff(original_path, proposed_path, real_file_path, cfg)
+    active_diffs[file_key] = result
+    -- Force terminal redraw via timer so RPC-triggered tab creation is visible
+    vim.fn.timer_start(10, function() vim.cmd("redraw!") end)
     return
   end
 
+  -- Side-by-side / tab layout
   apply_highlights(cfg)
 
   local display_name = real_file_path or "unknown"
   local labels = cfg.diff.labels or { current = "CURRENT", proposed = "PROPOSED" }
-
-  -- Detect filetype from the real file path for syntax highlighting
   local ft = vim.filetype.match({ filename = real_file_path }) or ""
 
-  -- Open a new tab (or vsplit based on layout config)
   if cfg.diff.layout == "vsplit" then
     vim.cmd("vsplit")
   else
     vim.cmd("tabnew")
   end
-  diff_tab = vim.api.nvim_get_current_tabpage()
+  local tab = vim.api.nvim_get_current_tabpage()
 
-  -- Left side: CURRENT (original file content)
+  -- Left side: CURRENT
   local orig_buf = vim.api.nvim_get_current_buf()
   vim.api.nvim_buf_set_lines(orig_buf, 0, -1, false, read_file_lines(original_path))
   vim.bo[orig_buf].buftype    = "nofile"
@@ -396,11 +414,15 @@ function M.show_diff(original_path, proposed_path, real_file_path, abs_file_path
   if ft ~= "" then vim.bo[orig_buf].filetype = ft end
 
   local orig_win = vim.api.nvim_get_current_win()
-  vim.wo[orig_win].winbar = "%#DiagnosticError# " .. labels.current .. " %* " .. display_name
+  local n = active_count()
+  local winbar_prefix = n > 0
+    and string.format("%%#DiagnosticError# %s [%d pending] %%* ", labels.current, n + 1)
+    or "%#DiagnosticError# " .. labels.current .. " %* "
+  vim.wo[orig_win].winbar = winbar_prefix .. display_name
   vim.api.nvim_win_set_hl_ns(orig_win, current_ns)
   vim.cmd("diffthis")
 
-  -- Right side: PROPOSED (what Claude wants to write)
+  -- Right side: PROPOSED
   vim.cmd("rightbelow vsplit")
   local prop_buf = vim.api.nvim_create_buf(false, true)
   vim.api.nvim_win_set_buf(0, prop_buf)
@@ -416,9 +438,8 @@ function M.show_diff(original_path, proposed_path, real_file_path, abs_file_path
   vim.api.nvim_win_set_hl_ns(prop_win, proposed_ns)
   vim.cmd("diffthis")
 
-  diff_bufs = { orig_buf, prop_buf }
+  local bufs = { orig_buf, prop_buf }
 
-  -- Show the full file (like VS Code diff) — open all folds
   if cfg.diff.full_file then
     for _, win in ipairs({ orig_win, prop_win }) do
       vim.wo[win].foldenable  = true
@@ -428,36 +449,45 @@ function M.show_diff(original_path, proposed_path, real_file_path, abs_file_path
     end
   end
 
-  -- Equalize window widths to 50/50
   if cfg.diff.equalize then
     vim.cmd("wincmd =")
   end
 
-  -- Re-equalize when terminal is resized (e.g. tmux pane zoom/unzoom)
-  diff_augroup = vim.api.nvim_create_augroup("CodePreviewDiffResize", { clear = true })
+  local augroup = vim.api.nvim_create_augroup("CodePreviewDiffResize_" .. file_key, { clear = true })
   vim.api.nvim_create_autocmd("VimResized", {
-    group = diff_augroup,
+    group = augroup,
     callback = function()
       if cfg.diff.equalize
-        and diff_tab
-        and vim.api.nvim_tabpage_is_valid(diff_tab)
-        and vim.api.nvim_get_current_tabpage() == diff_tab
+        and tab
+        and vim.api.nvim_tabpage_is_valid(tab)
+        and vim.api.nvim_get_current_tabpage() == tab
       then
         vim.cmd("wincmd =")
       end
     end,
   })
 
-  -- Jump to first diff change
+  active_diffs[file_key] = { tab = tab, bufs = bufs, augroup = augroup }
+
   vim.cmd("normal! ]c")
+
+  vim.fn.timer_start(10, function() vim.cmd("redraw!") end)
 end
 
-function M.close_diff()
-  if diff_tab and vim.api.nvim_tabpage_is_valid(diff_tab) then
-    local wins = vim.api.nvim_tabpage_list_wins(diff_tab)
-    -- Turn off diff mode first to avoid triggering DiffUpdated autocmds
-    -- during window close (works around Neovim crash in win_findbuf when
-    -- w_buffer is NULL during frame recalculation)
+--- Close the diff for a specific file and clean up its resources.
+function M.close_for_file(file_path)
+  local entry = active_diffs[file_path]
+  if not entry then
+    return
+  end
+
+  -- Clear neo-tree indicator (refresh is deferred until after the tab is closed
+  -- to avoid neo-tree walking a stale tabpage id)
+  pcall(function() require("code-preview.changes").clear(file_path) end)
+
+  -- Close the tab's windows
+  if entry.tab and vim.api.nvim_tabpage_is_valid(entry.tab) then
+    local wins = vim.api.nvim_tabpage_list_wins(entry.tab)
     for _, win in ipairs(wins) do
       if vim.api.nvim_win_is_valid(win) then
         pcall(vim.api.nvim_win_call, win, function() vim.cmd('diffoff') end)
@@ -470,51 +500,70 @@ function M.close_diff()
     end
   end
 
-  for _, buf in ipairs(diff_bufs) do
+  -- Delete buffers and clean up inline data
+  for _, buf in ipairs(entry.bufs or {}) do
+    buf_inline_data[buf] = nil
     if vim.api.nvim_buf_is_valid(buf) then
       pcall(vim.api.nvim_buf_delete, buf, { force = true })
     end
   end
 
-  if diff_augroup then
-    pcall(vim.api.nvim_del_augroup_by_id, diff_augroup)
-    diff_augroup = nil
+  -- Clean up augroup
+  if entry.augroup then
+    pcall(vim.api.nvim_del_augroup_by_id, entry.augroup)
   end
 
-  diff_tab  = nil
-  diff_bufs = {}
-  diff_file_path = nil
-  inline_line_numbers = {}
-  inline_line_types = {}
-  inline_diff_win = nil
+  active_diffs[file_path] = nil
 
-  -- If there's a queued diff, show it now
-  if #diff_queue > 0 then
-    local next_diff = table.remove(diff_queue, 1)
-    M.show_diff_from_lines(next_diff.orig_lines, next_diff.prop_lines,
-                           next_diff.real_file_path, next_diff.abs_file_path)
+  -- Refresh neo-tree after the tab is fully gone so it doesn't walk a stale tabpage.
+  -- The second delayed refresh picks up the real file after the backend writes it to disk.
+  vim.schedule(function()
+    pcall(function() require("code-preview.neo_tree").refresh() end)
+  end)
+  vim.defer_fn(function()
+    pcall(function() require("code-preview.neo_tree").refresh() end)
+  end, 500)
+end
+
+--- Legacy close_diff — closes the most recently focused diff tab.
+--- Used by backends that don't pass a file path.
+function M.close_diff()
+  -- Find which active diff is on the current tab
+  local current_tab = vim.api.nvim_get_current_tabpage()
+  for file_path, entry in pairs(active_diffs) do
+    if entry.tab == current_tab then
+      M.close_for_file(file_path)
+      return
+    end
+  end
+  -- Fallback: close the first one found
+  for file_path, _ in pairs(active_diffs) do
+    M.close_for_file(file_path)
+    return
   end
 end
 
---- Show a diff from pre-read line arrays (used by the queue).
---- Writes lines to temp files then delegates to show_diff().
-function M.show_diff_from_lines(orig_lines, prop_lines, real_file_path, abs_file_path)
-  local tmpdir = os.getenv("TMPDIR") or "/tmp"
-  local orig_path = tmpdir .. "/claude-diff-original"
-  local prop_path = tmpdir .. "/claude-diff-proposed"
-  local f = io.open(orig_path, "w")
-  if f then f:write(table.concat(orig_lines, "\n")); if #orig_lines > 0 then f:write("\n") end; f:close() end
-  f = io.open(prop_path, "w")
-  if f then f:write(table.concat(prop_lines, "\n")); if #prop_lines > 0 then f:write("\n") end; f:close() end
-  M.show_diff(orig_path, prop_path, real_file_path, abs_file_path)
-end
-
--- Close diff AND clear neo-tree indicators (for manual close via <leader>dq)
+-- Close ALL diffs and clear neo-tree indicators (for manual close via <leader>dq)
 function M.close_diff_and_clear()
-  diff_queue = {}  -- discard pending diffs on manual close
-  M.close_diff()
+  -- Collect keys first to avoid modifying table during iteration
+  local files = {}
+  for file_path, _ in pairs(active_diffs) do
+    files[#files + 1] = file_path
+  end
+  for _, file_path in ipairs(files) do
+    M.close_for_file(file_path)
+  end
   pcall(function() require("code-preview.changes").clear_all() end)
   pcall(function() require("code-preview.neo_tree").refresh() end)
+end
+
+--- Expose active_diffs for testing (read-only copy).
+function M._active_diffs()
+  local copy = {}
+  for k, v in pairs(active_diffs) do
+    copy[k] = { tab = v.tab, bufs = v.bufs }
+  end
+  return copy
 end
 
 return M

--- a/lua/code-preview/init.lua
+++ b/lua/code-preview/init.lua
@@ -7,7 +7,6 @@ local default_config = {
   diff = {
     layout = "tab",        -- "tab", "vsplit", or "inline"
     labels = { current = "CURRENT", proposed = "PROPOSED" },
-    auto_close = true,
     equalize = true,
     full_file = true,
     visible_only = false,  -- only show diffs for files open in a visible nvim window

--- a/tests/backends/claudecode/test_edit.sh
+++ b/tests/backends/claudecode/test_edit.sh
@@ -52,8 +52,9 @@ EOF
   change_status="$(nvim_eval "require('code-preview.changes').get('$test_file')")"
   assert_eq "modified" "$change_status" "file should be marked as modified" || return 1
 
-  # Proposed temp file should contain the edit result
-  local proposed="${TMPDIR:-/tmp}/claude-diff-proposed"
+  # Proposed temp file should contain the edit result (PID-suffixed)
+  local proposed
+  proposed="$(ls -1t "${TMPDIR:-/tmp}"/claude-diff-proposed-* 2>/dev/null | head -1)"
   assert_file_exists "$proposed" "proposed temp file should exist" || return 1
   local proposed_content
   proposed_content="$(cat "$proposed")"
@@ -261,7 +262,9 @@ EOF
   run_pretool_hook "$payload" >/dev/null
   sleep 0.5
 
-  local proposed="${TMPDIR:-/tmp}/claude-diff-proposed"
+  local proposed
+  proposed="$(ls -1t "${TMPDIR:-/tmp}"/claude-diff-proposed-* 2>/dev/null | head -1)"
+  assert_file_exists "$proposed" "proposed temp file should exist" || return 1
   local proposed_content
   proposed_content="$(cat "$proposed")"
   assert_not_contains "$proposed_content" "foo" "all occurrences of 'foo' should be replaced" || return 1

--- a/tests/backends/claudecode/test_stale_socket.sh
+++ b/tests/backends/claudecode/test_stale_socket.sh
@@ -131,8 +131,9 @@ EOF
   # project-specific nvim instance.
   assert_eq "0" "$exit_code" "hook must exit 0 without a guaranteed project nvim match" || return 1
 
-  # The proposed temp file must exist: headless nvim computed the edit.
-  local proposed="$hook_tmpdir/claude-diff-proposed"
+  # The proposed temp file must exist (PID-suffixed): headless nvim computed the edit.
+  local proposed
+  proposed="$(ls -1t "$hook_tmpdir"/claude-diff-proposed-* 2>/dev/null | head -1)"
   assert_file_exists "$proposed" "proposed file should be computed even without a project-specific nvim match" || return 1
   rm -rf "$hook_tmpdir"
 }

--- a/tests/helpers.sh
+++ b/tests/helpers.sh
@@ -62,7 +62,7 @@ reset_test_state() {
   nvim_exec "require('code-preview.diff').close_diff_and_clear()" 2>/dev/null || true
   # Remove temp files that persist across runs (shared by both backends)
   local _tmpdir="${TMPDIR:-/tmp}"
-  rm -f "$_tmpdir/claude-diff-original" "$_tmpdir/claude-diff-proposed"
+  rm -f "$_tmpdir"/claude-diff-original* "$_tmpdir"/claude-diff-proposed*
   sleep 0.3
 }
 

--- a/tests/plugin/diff_lifecycle_spec.lua
+++ b/tests/plugin/diff_lifecycle_spec.lua
@@ -100,7 +100,7 @@ describe("diff lifecycle", function()
     os.remove(prop)
   end)
 
-  it("show_diff queues when a diff for a different file is already open", function()
+  it("show_diff opens multiple tabs for different files simultaneously", function()
     local orig1 = tmp_file("q_orig1.txt", "file1 original")
     local prop1 = tmp_file("q_prop1.txt", "file1 proposed")
     local orig2 = tmp_file("q_orig2.txt", "file2 original")
@@ -110,16 +110,18 @@ describe("diff lifecycle", function()
     diff.show_diff(orig1, prop1, "file1.txt", "/abs/file1.txt")
     assert.is_true(diff.is_open("/abs/file1.txt"))
 
-    -- Show diff for file2 while file1 is open — should queue, not replace
+    -- Show diff for file2 while file1 is open — both should be active
     diff.show_diff(orig2, prop2, "file2.txt", "/abs/file2.txt")
-    assert.is_true(diff.is_open("/abs/file1.txt"))  -- file1 still showing
+    assert.is_true(diff.is_open("/abs/file1.txt"))  -- file1 still open
+    assert.is_true(diff.is_open("/abs/file2.txt"))  -- file2 also open
 
-    -- Close file1's diff — file2 should auto-show from queue
-    diff.close_diff()
+    -- Close file1's diff — file2 should remain
+    diff.close_for_file("/abs/file1.txt")
+    assert.is_false(diff.is_open("/abs/file1.txt"))
     assert.is_true(diff.is_open("/abs/file2.txt"))
 
     -- Close file2
-    diff.close_diff()
+    diff.close_for_file("/abs/file2.txt")
     assert.is_false(diff.is_open())
 
     os.remove(orig1)
@@ -128,18 +130,45 @@ describe("diff lifecycle", function()
     os.remove(prop2)
   end)
 
-  it("close_diff_and_clear discards the queue", function()
+  it("close_for_file leaves no stale tabpage references", function()
+    local orig = tmp_file("stale_orig.txt", "before")
+    local prop = tmp_file("stale_prop.txt", "after")
+
+    diff.show_diff(orig, prop, "stale.txt", "/abs/stale.txt")
+    assert.is_true(diff.is_open("/abs/stale.txt"))
+
+    -- Record the tab handle before closing
+    local tab_before = nil
+    for _, entry in pairs(diff._active_diffs()) do
+      tab_before = entry.tab
+    end
+    assert.is_not_nil(tab_before)
+
+    diff.close_for_file("/abs/stale.txt")
+
+    -- The diff must be gone from the active set
+    assert.is_false(diff.is_open("/abs/stale.txt"))
+
+    -- The tab must no longer be valid (no stale tabpage reference)
+    assert.is_false(vim.api.nvim_tabpage_is_valid(tab_before))
+
+    os.remove(orig)
+    os.remove(prop)
+  end)
+
+  it("close_diff_and_clear closes all active diffs", function()
     local orig1 = tmp_file("drain_orig1.txt", "aaa")
     local prop1 = tmp_file("drain_prop1.txt", "bbb")
     local orig2 = tmp_file("drain_orig2.txt", "ccc")
     local prop2 = tmp_file("drain_prop2.txt", "ddd")
 
     diff.show_diff(orig1, prop1, "drain1.txt", "/abs/drain1.txt")
-    diff.show_diff(orig2, prop2, "drain2.txt", "/abs/drain2.txt") -- queued
+    diff.show_diff(orig2, prop2, "drain2.txt", "/abs/drain2.txt")
 
     assert.is_true(diff.is_open("/abs/drain1.txt"))
+    assert.is_true(diff.is_open("/abs/drain2.txt"))
 
-    -- Manual close should discard the queue — file2 should NOT auto-show
+    -- close_diff_and_clear should close both diffs
     diff.close_diff_and_clear()
     assert.is_false(diff.is_open())
 


### PR DESCRIPTION
## Summary

- **Multi-tab diffs**: Each file edit opens its own diff tab instead of queuing. Solves OpenCode's multi-file workflow where all before-hooks fire before any after-hooks, causing only the last file's diff to appear.
- **Per-PID temp files**: Prevents collision between concurrent hook processes (`claude-diff-original-$$`).
- **Neo-tree stale tabpage fix**: Defers `neo_tree.refresh()` to after tab close via `vim.schedule()`, preventing `Invalid tabpage id` errors.
- **New file visibility**: Delayed second refresh ensures newly created files appear in neo-tree after the backend writes them to disk.
- **apply-edit.lua fix**: Empty `old_string` now correctly prepends `new_string` (handles new file creation via OpenCode).

## Test plan

- [x] All 18 Plenary unit tests pass (6 changes registry + 12 diff lifecycle)
- [x] All 22 backend shell tests pass
- [x] Manual: single-file Edit/Write with Claude Code — diff opens and closes on accept
- [x] Manual: multi-file edit with OpenCode — both tabs open simultaneously, close independently
- [x] Manual: new file creation — neo-tree shows created icon, file appears after accept
- [x] Manual: all three layouts (tab, vsplit, inline) work correctly