### PR TITLE
feat: make keymaps configurable via setup()

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,9 +217,29 @@ require("code-preview").setup({
 
 ## Keymaps
 
-| Key | Description |
-|-----|-------------|
-| `<leader>dq` | Close the diff (same as `:CodePreviewCloseDiff`) |
+| Key | Scope | Description |
+|-----|-------|-------------|
+| `<leader>dq` | global | Close the diff (same as `:CodePreviewCloseDiff`) |
+| `]c` | inline diff buffer | Jump to next change |
+| `[c` | inline diff buffer | Jump to previous change |
+
+All defaults are configurable via `setup()`:
+
+```lua
+require("code-preview").setup({
+  keys = {
+    next_change = "]c",          -- inline diff: next change
+    prev_change = "[c",          -- inline diff: previous change
+    close_all   = "<leader>dq",  -- close diff and clear indicators
+  },
+})
+```
+
+Set any entry to `false` to skip that binding, or `keys = false` to skip them all. A `<Plug>(CodePreviewCloseAll)` mapping is always defined, so you can bind it yourself even with `keys = false`:
+
+```lua
+vim.keymap.set("n", "<leader>x", "<Plug>(CodePreviewCloseAll)")
+```
 
 ---
 

--- a/lua/code-preview/diff.lua
+++ b/lua/code-preview/diff.lua
@@ -345,25 +345,32 @@ local function show_inline_diff(original_path, proposed_path, real_file_path, cf
     end
   end
 
-  vim.keymap.set("n", "]c", function()
-    local cur = vim.api.nvim_win_get_cursor(0)[1]
-    for lnum = cur + 1, vim.api.nvim_buf_line_count(buf) do
-      if line_types[lnum] then
-        vim.api.nvim_win_set_cursor(0, { lnum, 0 })
-        return
-      end
+  local keys_cfg = (cfg and cfg.keys) or {}
+  if keys_cfg ~= false then
+    if keys_cfg.next_change then
+      vim.keymap.set("n", keys_cfg.next_change, function()
+        local cur = vim.api.nvim_win_get_cursor(0)[1]
+        for lnum = cur + 1, vim.api.nvim_buf_line_count(buf) do
+          if line_types[lnum] then
+            vim.api.nvim_win_set_cursor(0, { lnum, 0 })
+            return
+          end
+        end
+      end, { buffer = buf, desc = "Next change" })
     end
-  end, { buffer = buf, desc = "Next change" })
 
-  vim.keymap.set("n", "[c", function()
-    local cur = vim.api.nvim_win_get_cursor(0)[1]
-    for lnum = cur - 1, 1, -1 do
-      if line_types[lnum] then
-        vim.api.nvim_win_set_cursor(0, { lnum, 0 })
-        return
-      end
+    if keys_cfg.prev_change then
+      vim.keymap.set("n", keys_cfg.prev_change, function()
+        local cur = vim.api.nvim_win_get_cursor(0)[1]
+        for lnum = cur - 1, 1, -1 do
+          if line_types[lnum] then
+            vim.api.nvim_win_set_cursor(0, { lnum, 0 })
+            return
+          end
+        end
+      end, { buffer = buf, desc = "Previous change" })
     end
-  end, { buffer = buf, desc = "Previous change" })
+  end
 
   if first_change_line then
     vim.api.nvim_win_set_cursor(win, { first_change_line, 0 })

--- a/lua/code-preview/init.lua
+++ b/lua/code-preview/init.lua
@@ -33,6 +33,13 @@ local default_config = {
       deleted  = { fg = "#e06c75", bold = true, strikethrough = true },
     },
   },
+  keys = {
+    -- Set any entry to false to skip that binding. Set `keys = false` to skip all.
+    -- <Plug>(CodePreviewCloseAll) is always defined so users can map it themselves.
+    next_change = "]c",        -- buffer-local in inline diff buffers
+    prev_change = "[c",        -- buffer-local in inline diff buffers
+    close_all   = "<leader>dq", -- global; close diff and clear indicators
+  },
   highlights = {
     current = {
       DiffAdd    = { bg = "#4c2e2e" },
@@ -140,9 +147,19 @@ function M.setup(user_config)
     require("code-preview.neo_tree").setup(M.config)
   end
 
-  vim.keymap.set("n", "<leader>dq", function()
+  -- <Plug> mapping is always defined so users can bind it themselves
+  -- regardless of the `keys` config (e.g. `keys = false` to disable defaults).
+  vim.keymap.set("n", "<Plug>(CodePreviewCloseAll)", function()
     require("code-preview.diff").close_diff_and_clear()
   end, { desc = "Close code-preview diff" })
+
+  if M.config.keys ~= false then
+    local close_all = M.config.keys and M.config.keys.close_all
+    if close_all then
+      vim.keymap.set("n", close_all, "<Plug>(CodePreviewCloseAll)",
+        { desc = "Close code-preview diff" })
+    end
+  end
 end
 
 --- Query hook context for the PreToolUse shell script.


### PR DESCRIPTION
## Summary
- Adds a `keys` table to `setup()` so the previously hardcoded mappings (`]c`, `[c`, `<leader>dq`) can be customized or disabled
- Always defines `<Plug>(CodePreviewCloseAll)` for users who prefer to bind the close action themselves
- Defaults match the existing hardcoded values, so behavior is unchanged for current users

Closes #43

## Usage

```lua
require("code-preview").setup({
  keys = {
    next_change = "]c",          -- inline diff: next change
    prev_change = "[c",          -- inline diff: previous change
    close_all   = "<leader>dq",  -- close diff and clear indicators
  },
})
```

Set any entry to `false` to skip that binding, or `keys = false` to skip them all and use `<Plug>(CodePreviewCloseAll)` directly.

## Test plan
- [x] Defaults (`]c`/`[c`/`<leader>dq`) work unchanged across Claude Code, OpenCode, and GitHub Copilot CLI backends
- [x] Custom keys (e.g. `<leader>cn`/`<leader>cp`/`<leader>cq`) bind correctly and the original defaults no longer trigger
- [x] `keys = false` disables all defaults; `<Plug>(CodePreviewCloseAll)` still bindable manually
- [x] Per-key `false` (e.g. `close_all = false`) skips just that binding