### PR TITLE
fix: support NVIM_APPNAME in XDG_RUNTIME_DIR socket discovery

### DIFF
--- a/bin/nvim-socket.sh
+++ b/bin/nvim-socket.sh
@@ -79,15 +79,16 @@ find_nvim_socket() {
   # 4. Scan XDG_RUNTIME_DIR paths (NixOS, systemd-based distros)
   # Complements step 3; on these systems sockets live in $XDG_RUNTIME_DIR, not /tmp
   local _xdg_dir="${XDG_RUNTIME_DIR:-}"
+  local _appname="${NVIM_APPNAME:-nvim}"
   if [[ -z "$_xdg_dir" ]]; then
     _xdg_dir="/run/user/$(id -u)"
   fi
   local _xdg_glob_out
-  _xdg_glob_out="$(compgen -G "$_xdg_dir/nvim.*.0" 2>/dev/null)" || true
+  _xdg_glob_out="$(compgen -G "$_xdg_dir/${_appname}.*.0" 2>/dev/null)" || true
   if [[ -n "$_xdg_glob_out" ]]; then
     while IFS= read -r socket; do
       if [[ -S "$socket" ]]; then
-        pid=$(echo "$socket" | grep -oE 'nvim\.[0-9]+' | grep -oE '[0-9]+')
+        pid=$(echo "$socket" | grep -oE "${_appname}\\.[0-9]+" | grep -oE '[0-9]+')
         if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
           live_sockets+=("$pid:$socket")
         fi


### PR DESCRIPTION
  ## Problem

  When `NVIM_APPNAME` is set (e.g. `NVIM_APPNAME=lazynvim`), Neovim generates
  socket filenames using the custom app name instead of "nvim":

      /run/user/<uid>/lazynvim.97652.0

  The current glob `nvim.*.0` in step 4 fails to discover these sockets.

  ## Root Cause

  Neovim's `server_address_new()` uses `get_appname()` (which reads
  `$NVIM_APPNAME`, defaulting to "nvim") as the socket filename prefix:

      $XDG_RUNTIME_DIR/$NVIM_APPNAME.$PID.$COUNT

  Reference: https://github.com/neovim/neovim/blob/d9a7b687955bd1af377dba56b87479acd7141f87/src/nvim/msgpack_rpc/server.c#L128-L129 and https://github.com/neovim/neovim/blob/d9a7b687955bd1af377dba56b87479acd7141f87/src/nvim/os/stdpaths.c#L71

  ## Fix

  Use `$NVIM_APPNAME` (defaulting to "nvim") to construct the glob pattern
  dynamically in the XDG_RUNTIME_DIR scan.
