### PR TITLE
feat: pidfile-based socket discovery (#47, phase 1)

### DIFF
--- a/bin/nvim-socket.sh
+++ b/bin/nvim-socket.sh
@@ -48,6 +48,41 @@ find_nvim_socket() {
   local live_sockets=()
   local socket pid
 
+  # 2a. Pidfile discovery — each running nvim that called code-preview.setup()
+  # registers itself at ${XDG_STATE_HOME:-$HOME/.local/state}/code-preview/sockets/<pid>.
+  # File contents: line 1 = socket path, line 2 = cwd. Cheaper and OS-portable
+  # vs the glob-based discovery below, which we keep as a fallback for nvim
+  # instances that haven't been restarted since the upgrade.
+  local _state_home="${XDG_STATE_HOME:-$HOME/.local/state}"
+  local _pidfile_dir="$_state_home/code-preview/sockets"
+  if [[ -d "$_pidfile_dir" ]]; then
+    local pidfile pf_socket pf_cwd
+    for pidfile in "$_pidfile_dir"/*; do
+      [[ -f "$pidfile" ]] || continue
+      pid="$(basename "$pidfile")"
+      [[ "$pid" =~ ^[0-9]+$ ]] || continue
+      { IFS= read -r pf_socket; IFS= read -r pf_cwd; } < "$pidfile" || continue
+      [[ -n "$pf_socket" && -S "$pf_socket" ]] || continue
+
+      # Validate socket is responsive — self-heals stale pidfiles from crashed
+      # nvim where the PID may even have been recycled.
+      if ! nvim --server "$pf_socket" --remote-expr "1" >/dev/null 2>&1; then
+        continue
+      fi
+
+      # If project_cwd given, check match-or-parent rule using the cwd the
+      # nvim itself reported (more accurate than lsof, which gives startup cwd).
+      if [[ -n "$project_cwd" && -n "$pf_cwd" ]]; then
+        if [[ "$project_cwd" == "$pf_cwd" || "$project_cwd" == "$pf_cwd/"* ]]; then
+          eval "$_oldopts"
+          echo "$pf_socket"
+          return 0
+        fi
+      fi
+      live_sockets+=("$pid:$pf_socket")
+    done
+  fi
+
   # 2. Scan macOS /var/folders paths
   local _glob_out
   _glob_out="$(compgen -G '/var/folders/*/*/T/nvim.*/*/nvim.*.0' 2>/dev/null)" || true

--- a/lua/code-preview/health.lua
+++ b/lua/code-preview/health.lua
@@ -25,6 +25,23 @@ function M.check()
   local layout = (cfg.diff and cfg.diff.layout) or "unknown"
   ok("Diff layout: " .. layout)
 
+  -- Pidfile registration — used by hook scripts to find this nvim's socket
+  -- without OS-specific socket-glob discovery.
+  local pidfile = require("code-preview.pidfile").path()
+  local pf = io.open(pidfile, "r")
+  if not pf then
+    warn("Pidfile not found at " .. pidfile .. " (hook scripts will fall back to socket discovery)")
+  else
+    local pf_socket = pf:read("*l") or ""
+    local pf_cwd = pf:read("*l") or ""
+    pf:close()
+    if pf_socket == "" or pf_cwd == "" then
+      warn("Pidfile " .. pidfile .. " is malformed (expected socket+cwd on two lines)")
+    else
+      ok("Pidfile registered: " .. pidfile)
+    end
+  end
+
   -- ── Claude Code backend ───────────────────────────────────────
 
   start("Claude Code backend")

--- a/lua/code-preview/init.lua
+++ b/lua/code-preview/init.lua
@@ -91,6 +91,9 @@ function M.setup(user_config)
   -- Initialise logging
   require("code-preview.log").init({ debug = M.config.debug })
 
+  -- Self-register socket + cwd for hook-script discovery
+  require("code-preview.pidfile").setup()
+
   -- ── New commands ──────────────────────────────────────────────
 
   vim.api.nvim_create_user_command("CodePreviewInstallClaudeCodeHooks", function()
@@ -224,6 +227,14 @@ function M.status()
     table.insert(lines, "Neovim socket : " .. socket)
   else
     table.insert(lines, "Neovim socket : not found")
+  end
+
+  -- Pidfile (used by hook scripts for socket discovery)
+  local pidfile = require("code-preview.pidfile").path()
+  if vim.fn.filereadable(pidfile) == 1 then
+    table.insert(lines, "Pidfile       : " .. pidfile)
+  else
+    table.insert(lines, "Pidfile       : not registered")
   end
 
   -- jq dependency

--- a/lua/code-preview/pidfile.lua
+++ b/lua/code-preview/pidfile.lua
@@ -1,0 +1,69 @@
+-- pidfile.lua — Self-registers this nvim's RPC socket + cwd so the hook
+-- scripts can find it without OS-specific socket-glob discovery.
+--
+-- File format (two lines):
+--   <socket path>
+--   <cwd>
+--
+-- Location: ${XDG_STATE_HOME:-$HOME/.local/state}/code-preview/sockets/<pid>
+-- The same path is computed by bin/nvim-socket.sh.
+
+local M = {}
+
+function M.dir()
+  local state = vim.env.XDG_STATE_HOME
+  if not state or state == "" then
+    state = (vim.env.HOME or "") .. "/.local/state"
+  end
+  return state .. "/code-preview/sockets"
+end
+
+function M.path()
+  return M.dir() .. "/" .. tostring(vim.fn.getpid())
+end
+
+local function write()
+  local socket = vim.v.servername or ""
+  if socket == "" then return end
+
+  vim.fn.mkdir(M.dir(), "p")
+
+  local f, err = io.open(M.path(), "w")
+  if not f then
+    require("code-preview.log").warn("pidfile: open failed: " .. tostring(err))
+    return
+  end
+  f:write(socket, "\n", vim.fn.getcwd(), "\n")
+  f:close()
+end
+
+local function remove()
+  pcall(os.remove, M.path())
+end
+
+function M.setup()
+  -- Initial write
+  pcall(write)
+
+  local group = vim.api.nvim_create_augroup("CodePreviewPidfile", { clear = true })
+
+  -- Refresh cwd line when the user :cd's so socket discovery stays accurate.
+  vim.api.nvim_create_autocmd("DirChanged", {
+    group = group,
+    callback = function() pcall(write) end,
+  })
+
+  -- Re-write if servername changes (rare, but possible via :let v:servername).
+  vim.api.nvim_create_autocmd("VimEnter", {
+    group = group,
+    callback = function() pcall(write) end,
+  })
+
+  -- Cleanup on exit
+  vim.api.nvim_create_autocmd("VimLeavePre", {
+    group = group,
+    callback = remove,
+  })
+end
+
+return M


### PR DESCRIPTION
Phase 1 of #47 — replaces OS-specific socket-glob discovery with a self-registered pidfile that each nvim writes on `setup()`.

## Summary

- Each nvim running `code-preview.setup()` writes `~/.local/state/code-preview/sockets/<pid>` containing its RPC socket path and current cwd (two lines).
- `bin/nvim-socket.sh` checks this directory first, validates the socket is responsive, applies the same match-or-parent-cwd rule as before, and falls back to the existing `/var/folders` / `/tmp` / `$XDG_RUNTIME_DIR` discovery if no pidfile matches.
- `:CodePreviewStatus` and `:checkhealth code-preview` both surface pidfile state.

## Why

The glob-based discovery relies on `lsof`, `compgen`, `kill -0`, and `/proc` — none of which exist natively on Windows. This is the main blocker for #46. The pidfile is computable from any platform and stores cwd directly, eliminating the `lsof` lookup that today returns the process's *startup* cwd rather than the user's current `:cd`.

## Behavior preserved

- Multi-instance routing via the same match-or-parent-cwd rule
- `NVIM_LISTEN_ADDRESS` override (still checked first)
- Single-instance / fallback case (legacy globs still run when no pidfile matches, so users running an older nvim alongside the upgraded plugin keep working)

## Behavior improved

- Liveness check is now socket-connect, not `kill -0` — catches hung nvim with a live PID
- cwd is read live from nvim and refreshed on `DirChanged`, so `:cd`-ing to a different project routes correctly without restarting nvim

## Scope

This is phase 1 of a four-phase migration. The pidfile itself is permanent — phases 2–4 (orchestration porting to Lua) will continue to read from the same pidfile dir. `nvim-socket.sh` will be removed entirely in a later phase.

Out of scope here:
- Windows-portability of the bash itself (`-S` test, path separators) — not worth it on a file we're deleting
- Phase 2+ orchestration changes

## Test plan

- [x] Pidfile written with correct socket + cwd on `setup()`
- [x] `DirChanged` refreshes cwd line on `:cd`
- [x] `VimLeavePre` removes the pidfile on `:qa`
- [x] `nvim-socket.sh` resolves the right socket via pidfile (single instance)
- [x] Multi-instance routing — two nvims at different cwds, each gets its own edits
- [x] Subdirectory match — `cd repo/lua` still resolves to nvim opened at `repo/`
- [x] Fallback to legacy globs when pidfile dir is empty/missing
- [x] End-to-end Claude Code edit lands in the correct nvim
- [x] `:CodePreviewStatus` shows pidfile path
- [x] `:checkhealth code-preview` shows pidfile registration status

🤖 Generated with [Claude Code](https://claude.com/claude-code)