### PR TITLE
docs: establish baseline glossary and ADRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# Agents
+
+Pointers for AI coding agents working in this repository.
+
+## Agent skills
+
+### Issue tracker
+
+Issues live in the `Cannon07/code-preview` GitHub repo; skills use the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default canonical label vocabulary (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context layout — `CONTEXT.md` and `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,200 @@
+# Glossary
+
+The vocabulary code-preview.nvim is written in. When naming things in commits, issues, tests, docs, or code, prefer the terms defined here over synonyms.
+
+---
+
+## Agent
+
+An external AI coding CLI that proposes file edits and asks the user for permission before applying them. The plugin's reason for existing: previewing those proposals inside Neovim before the agent acts.
+
+Supported agents today: **Claude Code**, **OpenCode**, **Codex CLI**, **GitHub Copilot CLI**. Each one fires hooks (or the agent's equivalent) on every proposed edit, which the plugin intercepts.
+
+The directory `backends/` and the env var `CODE_PREVIEW_BACKEND` are historical names for what we now call an agent. Don't rename them — the cost outweighs the benefit — but in conversation, design docs, and new code, say "agent."
+
+## Integration
+
+The per-agent adapter that translates that agent's hook format into the plugin's normalised core. One integration per agent. Each integration has two parts:
+
+- **Installer** (`lua/code-preview/backends/<agent>.lua`) — wires the agent's config files (e.g. `.claude/settings.local.json`, `.opencode/plugins/index.ts`) to point at the plugin's hook scripts.
+- **Hook entry** (`backends/<agent>/code-{preview,close}-diff.sh`) — see [Hook entry](#hook-entry).
+
+When a doc or issue says "the Codex integration," it means the installer + adapter scripts for Codex — never the running Codex CLI itself.
+
+## Proposal
+
+One agent action that wants to touch the filesystem — a single firing of the agent's pre-tool hook. Corresponds 1:1 with an Edit / Write / MultiEdit / Bash / ApplyPatch invocation by the agent.
+
+A proposal can produce zero, one, or many [previews](#preview):
+
+- Edit / Write / MultiEdit — one preview per call (single file).
+- ApplyPatch — one preview per file in the patch.
+- Bash — zero previews; the plugin only updates change indicators (no content diff is rendered).
+
+Do not say "tool use" or "tool call" in plugin-side docs — those are agent-side terms. The plugin sees proposals.
+
+## Preview
+
+The per-file unit of pending review. One open diff tab (or vsplit, or inline buffer) keyed by absolute file path in `active_diffs`. A preview *contains* a diff; "diff" is the content (added/removed lines), "preview" is the thing the user opens, scrolls, and closes.
+
+Lifecycle: a [proposal](#proposal) creates one or more previews → the user reviews them → the agent's post-tool hook closes the matching previews (whether the user accepted or rejected on the agent's side).
+
+Prefer "preview" over "diff" when naming the unit: `close_for_file` closes a preview; the buffer inside it displays a diff.
+
+## RPC
+
+The transport that lets an [integration](#integration)'s shell scripts call into the running Neovim. Implemented by `bin/nvim-call.sh` (caller side) and `lua/code-preview/rpc.lua` (dispatcher side): a JSON args array is written to a tempfile, then `luaeval` invokes the named module function with those args decoded.
+
+A single request → response invocation is an **RPC call**. We do not yet need a more specific name for the call shape; #47 may still reshape it.
+
+## Socket discovery
+
+The act of finding which running Neovim instance to address an RPC call at. Resolution order (see `bin/nvim-socket.sh`):
+
+1. `$NVIM_LISTEN_ADDRESS` env var, if its socket is responsive.
+2. **Pidfile** lookup — preferred path since #47 phase 1.
+3. Glob `/var/folders/*/T/nvim.*/0` (macOS default tempdir).
+4. Glob `/tmp/${NVIM_APPNAME}.*/0` (Linux + some macOS setups).
+5. Glob `$XDG_RUNTIME_DIR/${NVIM_APPNAME}.*.0` (NixOS, systemd-based distros).
+
+If multiple instances match, prefer the one whose cwd matches (or is a parent of) the project cwd passed in by the calling hook.
+
+## Pidfile
+
+One file per running Neovim that has called `code-preview.setup()`. Path: `${XDG_STATE_HOME:-$HOME/.local/state}/code-preview/sockets/<pid>`. Contents: line 1 is the RPC socket path, line 2 is the Neovim's cwd.
+
+Pidfiles self-register on `setup()`, refresh on `DirChanged`, and are removed on `VimLeavePre`. Crashed Neovims leave stale pidfiles behind; `socket discovery` self-heals by probing each socket with `--remote-expr "1"` before using it.
+
+The pidfile is *one of several* socket discovery paths, not a synonym for socket discovery.
+
+## Hook entry
+
+The per-agent script the agent invokes directly when it's about to (or has just) used an editing tool. One pair per [integration](#integration): `code-preview-diff.sh` for pre-tool, `code-close-diff.sh` for post-tool. Lives in `backends/<agent>/`.
+
+Job: take the agent's native hook payload, normalise it into the shape the [core handler](#core-handler) expects (`{tool_name, cwd, tool_input}`), then hand off. Whatever language the agent demands (today: shell) is the language of the hook entry.
+
+## Core handler
+
+The agent-neutral pipeline that, given a normalised proposal, decides whether to show a preview, computes the original and proposed file content, and makes the [RPC](#rpc) call into the running Neovim. Today: `bin/core-pre-tool.sh` and `bin/core-post-tool.sh`. Issue #47 phases 3 and 4 replace these with Lua equivalents run via `nvim --headless -l`; the role stays the same.
+
+The core handler is where shell-write detection, `visible_only` gating, and `permissionDecision` emission live — everything that doesn't depend on which agent fired the hook.
+
+## Dispatcher
+
+The in-process Lua entry point that receives an RPC call and invokes the target function. Exported as `M.dispatch(mod, fn, args_file)` in `lua/code-preview/rpc.lua`. Reads the JSON args file written by `nvim-call.sh`, decodes it, looks up `require(mod)[fn]`, and calls it.
+
+The dispatcher is the *only* place user-controlled data crosses the bash/Lua boundary, and it never enters a Lua source string — that property is the whole reason the dispatcher exists (see issue #47 phase 2).
+
+## Change
+
+One entry in the changes registry (`lua/code-preview/changes.lua`): `{absolute_path → status}`. A change records that the agent has recently touched the file; it does not imply a [preview](#preview) is open. Bash writes set changes without ever producing a preview.
+
+A change is set by the [core handler](#core-handler) before the [proposal](#proposal) is shown, and cleared by the post-tool handler once the agent reports the proposal is done (accepted or rejected).
+
+## Status
+
+The value side of a change. The five recognised statuses:
+
+- `modified` — Edit / Write / MultiEdit / ApplyPatch on an existing file.
+- `created` — same tools, on a path that didn't exist beforehand.
+- `deleted` — explicit deletion (`*** Delete File:` in a patch, or `rm` detected in a Bash command).
+- `bash_modified` — Bash write detected against an existing file.
+- `bash_created` — Bash write detected against a path that didn't exist.
+
+The `bash_` prefix is an **origin prefix** — see [Origin prefix](#origin-prefix).
+
+## Origin prefix
+
+A convention on [status](#status) values that records which kind of agent action produced the change. Today only `bash_*` is prefixed; un-prefixed statuses (`modified`, `created`, `deleted`) come from structured editing tools (Edit/Write/MultiEdit/ApplyPatch) or from explicit `rm` detection.
+
+Origin prefixes exist because some agents (observed with GPT-class models in Codex) route file edits through `Bash`, which the plugin can't safely preview. Those proposals degrade to indicator-only ([Tier 1](#tier-1--tier-2)), and the prefix lets the Bash post-tool clear its own markers without clobbering markers from a concurrent structured proposal. See [ADR-0001](docs/adr/0001-origin-prefixed-status-values.md).
+
+## Tier 1 / Tier 2
+
+Two levels of fidelity for handling `Bash` proposals.
+
+- **Tier 1** — *implemented today.* Static regex parsing of the shell command for redirections (`>`, `>>`), atomic-replace (`mv X.tmp X`), `cp`, `tee`, and `sed -i` targets. Sets a [change](#change) with a `bash_*` [origin prefix](#origin-prefix); does **not** open a [preview](#preview). The user sees the file was touched via the neo-tree [indicator](#indicator) but reviews the actual content via their normal diff workflow after the fact.
+- **Tier 2** — *not implemented.* Would compute and display real content diffs for shell-writes. Open design question; sandboxing was rejected (see [ADR-0001](docs/adr/0001-origin-prefixed-status-values.md)). The name exists so deferred work has a label, not a commitment.
+
+## Source path / File path / Display path
+
+Three distinct path concepts used together in the [preview](#preview) pipeline. They are *not* interchangeable; the current code muddles them (see [issue #55](https://github.com/Cannon07/code-preview.nvim/issues/55)).
+
+- **Source path** — a temp file holding pre-rendered content (`/tmp/claude-diff-{original,proposed}-<pid>`). One pair per preview: `original_source_path` and `proposed_source_path`. Scratch files, not the real file.
+- **File path** — the absolute canonical path of the real file being edited. The *identity*: used as the key in `active_diffs`, passed to the [changes](#change) registry, used by neo-tree reveal.
+- **Display path** — what's rendered in the winbar. Usually cwd-relative for readability; never used as an identity.
+
+When in doubt: identity = file path; content = source path; UI label = display path.
+
+## Visible-only mode
+
+Opt-in restriction (`diff.visible_only` config, default `false`) that suppresses [previews](#preview) for files not currently visible in any Neovim window. The [core handler](#core-handler) asks the running Neovim via `hook_context()` whether the target file is in any window's visible buffer; if `visible_only` is on and the file isn't visible, the preview is skipped entirely (no diff tab, no inline buffer). [Change indicators](#indicator) in neo-tree still fire — visible-only mode is about avoiding *modal* interruption, not about hiding that the edit happened.
+
+Toggled at runtime via `:CodePreviewToggleVisibleOnly`.
+
+## Review gate
+
+The pause window between an agent firing the pre-tool hook and the agent actually writing the file — the moment during which the [preview](#preview) is on screen and the user can accept or reject. Every supported agent has a review gate; the *mechanism* differs per [integration](#integration):
+
+- **Claude Code** — the plugin emits `permissionDecision: "ask"` in the pre-tool hook output, which forces Claude Code to prompt. Suppressible with `diff.defer_claude_permissions = true`, which delegates to Claude Code's own permission settings (bypass, ask, allowlist). See [ADR-0002](docs/adr/0002-default-force-review-gate.md) for why the default forces the gate.
+- **OpenCode** — gated through OpenCode's plugin API.
+- **Codex / Copilot CLI** — relies on the agent's native ask-before-write loop.
+
+The plugin doesn't *implement* the gate; it lives inside the agent. The plugin's job is to make sure the gate fires (Claude Code's case) and to render a useful preview *during* the gate.
+
+## Layout
+
+The user-facing config value (`diff.layout`) that selects how a [preview](#preview) is rendered. Three values: `"tab"`, `"vsplit"`, `"inline"`. The first two share one [renderer](#renderer); `"inline"` uses the other.
+
+## Renderer
+
+The internal rendering path. Two of them:
+
+- **Side-by-side renderer** — opens a CURRENT and a PROPOSED buffer in two windows, uses Neovim's built-in `:diffthis`. Used by both `tab` and `vsplit` layouts (the only difference is whether the windows live in a new tab or a vsplit of the current one). The legacy default.
+- **Inline renderer** — single buffer showing a unified-diff view, with character-level highlights, `]c` / `[c` navigation, and a custom statuscolumn displaying old|new line numbers. Implemented in `build_inline_diff` + `inline_statuscolumn` in `lua/code-preview/diff.lua`.
+
+The inline renderer is the strategic direction — see [ADR-0003](docs/adr/0003-inline-renderer-as-future-default.md). The side-by-side renderer is kept available but is no longer where new rendering features land.
+
+## Reveal
+
+The behaviour that scrolls neo-tree to the file touched by a [proposal](#proposal), so the user can see the [change indicator](#indicator) in context. Config: `neo_tree.reveal` (boolean, default on), `neo_tree.reveal_root` (`"cwd"` or `"git"` — which root neo-tree opens from).
+
+Implementation lives in `lua/code-preview/neo_tree.lua`; the [core handler](#core-handler) and `diff.show_diff` call `reveal` / `reveal_deferred` after marking the [change](#change). The deferred variant exists because neo-tree needs a moment to settle after window changes.
+
+**Reveal target** — the path neo-tree is asked to scroll to. For `modified`/`deleted` [statuses](#status) it's the file itself. For `created`, the file doesn't yet exist on disk, so the target falls back to the nearest existing ancestor directory (or a sibling within it) — neo-tree can't highlight a path that isn't in its tree.
+
+Precedence rule: when a Bash command both deletes and writes (`rm a && echo x > b`), the `rm`-driven reveal wins.
+
+## Hook context query
+
+An [RPC](#rpc) call the [core handler](#core-handler) issues to the running Neovim early in every hook invocation, to read config + transient state in a single hop. Two main call sites:
+
+- `code-preview.log.state` — returns `{debug, log_file}`. The shell handler uses this to decide whether to emit debug log lines and where.
+- `code-preview.hook_context(file_path)` — returns `{neo_tree_reveal, reveal_root, visible_only, file_visible, defer_claude_permissions, debug, log_file}`. The transient bit is `file_visible`: whether `file_path` is currently shown in any visible window (only computed when [visible-only mode](#visible-only-mode) is on).
+
+The pattern exists because the bash layer holds no config of its own — see [ADR-0004](docs/adr/0004-config-lives-only-in-neovim.md). If Neovim is unreachable, the hook degrades safely (no logging, no [review gate](#review-gate), no visibility filter).
+
+## Headless worker
+
+A short-lived Neovim spawned with `nvim --headless -l <script>.lua` to do work *outside* the user's running Neovim. Headless workers have no UI, no access to the user's `M.config` or open buffers, and communicate via stdin / stdout / exit code or via [RPC](#rpc) back to the user's instance.
+
+Today's headless workers:
+
+- `bin/apply-edit.lua` — computes the proposed content for an `Edit` proposal.
+- `bin/apply-multi-edit.lua` — same for `MultiEdit`.
+- `bin/apply-patch.lua` — parses the custom patch format and emits per-file orig/prop tempfiles for `ApplyPatch`.
+
+After issue #47 phases 3 and 4, `bin/core-pre-tool.lua` and `bin/core-post-tool.lua` will join this category — the entire [core handler](#core-handler) becomes a headless worker. At that point, "bash core handler" goes away as a concept and "headless worker" is *the* extra-process model.
+
+## In-process Lua vs headless Lua
+
+The plugin has two Lua code categories with different rules.
+
+- **In-process Lua** — runs inside the user's running Neovim. Has access to `M.config`, open buffers, windows, autocmds, neo-tree, the [changes](#change) registry. Lives under `lua/code-preview/`. Examples: `init.lua`, `diff.lua`, `rpc.lua`'s `dispatch`, `pidfile.lua`'s `setup`.
+- **Headless Lua** — runs in a [headless worker](#headless-worker). No access to the user's session. Must communicate findings back via stdout, tempfiles, or RPC. Lives under `bin/`. Examples: `apply-edit.lua`, `apply-patch.lua`.
+
+When deciding where new code belongs: anything that needs to *see or change the user's Neovim state* is in-process; anything that just transforms data is a candidate for a headless worker, and after #47 phases 3/4 the orchestration around it lives in a headless worker too.
+
+## Indicator
+
+The rendered icon and highlight in the neo-tree filesystem source for a file that has a [change](#change). One indicator per change. The mapping from status → glyph + highlight is configured under `neo_tree.symbols` and `neo_tree.highlights`. The indicator is *the visual*; the change is *the data*.

--- a/docs/adr/0001-origin-prefixed-status-values.md
+++ b/docs/adr/0001-origin-prefixed-status-values.md
@@ -1,0 +1,25 @@
+# Bash proposals are indicator-only, with origin-prefixed statuses
+
+Some agents — observed first with GPT-class models in the Codex integration — route file edits through the `Bash` tool instead of structured `Edit`/`Write`/`MultiEdit` calls. The plugin cannot safely render a content preview for arbitrary shell: doing so would require either dry-running the command in a sandbox (expensive, unsafe) or snapshotting and re-inspecting around the agent's execution (intrusive, racy). Two decisions follow from that constraint:
+
+1. **Bash proposals never produce a [preview](../../CONTEXT.md#preview).** They only update [change indicators](../../CONTEXT.md#indicator) in the registry, so the user at least sees in neo-tree that the file was touched. This is the "Tier 1" path in `bin/core-pre-tool.sh`. A future "Tier 2" with real content diffs is named but not committed to.
+2. **Bash-origin statuses are prefixed** (`bash_modified`, `bash_created`). The registry is a flat `{path → status}` map shared across all in-flight proposals; the Bash post-tool needs to clear *only its own* markers without clobbering markers from a concurrent Edit/Write/ApplyPatch whose post-tool hasn't fired. The prefix lets it do `clear_by_statuses(["deleted", "bash_modified", "bash_created"])` instead of a blind path-keyed clear.
+
+## Considered Options
+
+For the indicator-only policy:
+
+- **Dry-run the command in a sandbox to compute the proposed diff.** Rejected: arbitrary shell can read network, mutate global state, and consume real time. Not safe to run speculatively, and would block the agent on every Bash proposal.
+- **Snapshot before + diff after the agent runs.** Rejected: requires hooking *both* pre and post around the actual write, and the diff would be shown after the agent has already committed — too late to be a preview in any meaningful sense.
+
+For encoding origin in the registry:
+
+- **Single status with a separate origin column** (`{path → {status, origin}}`). Rejected: doubles the shape of every entry to serve one call site.
+- **Per-tool sub-registries.** Rejected: complicates the common-case lookup (rendering an indicator) for a problem only the post-tool clear has.
+
+## Consequences
+
+- New origins (e.g. a future LSP-driven write detector) follow the same convention: `<origin>_modified`, `<origin>_created`.
+- Renderers must map prefixed statuses to the same indicator as their un-prefixed counterpart, or they'll silently miss change icons. Today this mapping is centralised in `lua/code-preview/neo_tree.lua`.
+- The `deleted` status is intentionally un-prefixed: `rm` detection lives in the Bash core path but `*** Delete File:` patch directives produce the same status from a structured-tool path, so origin isn't a clean discriminator there.
+- If we ever build Tier 2 (real content diffs for shell writes), Bash proposals would start producing previews and the indicator-only assumption would need revisiting — but the prefix convention would still hold for the period when both tiers coexist.

--- a/docs/adr/0002-default-force-review-gate.md
+++ b/docs/adr/0002-default-force-review-gate.md
@@ -1,0 +1,17 @@
+# Default to forcing the Claude Code review gate
+
+For the Claude Code integration, the pre-tool hook emits `permissionDecision: "ask"` by default — forcing Claude Code to prompt the user on every edit, even when the user has configured permissive settings (bypass mode, allowlists). Users can opt out with `diff.defer_claude_permissions = true`, which suppresses the JSON output and lets Claude Code's own settings decide.
+
+The reason: the plugin's value proposition is *previewing edits before they land*. If Claude Code is in bypass mode or has the edit allowlisted, the [review gate](../../CONTEXT.md#review-gate) never opens — the agent writes the file immediately and the preview appears alongside an already-committed change, which is worse than no preview at all (the user might assume the diff is pending when it isn't). Defaulting to a forced gate ensures the preview *means something*: there is a real accept/reject moment that lines up with what's on screen.
+
+## Considered Options
+
+- **Default = respect Claude Code's permission settings.** Rejected: users who installed the plugin specifically to get previews would silently lose them whenever Claude Code's settings let an edit through. Surprising and quiet, which is the worst kind of behaviour.
+- **No config knob; always force the gate.** Rejected: a user who deliberately wants Claude Code's permission machinery to be authoritative (e.g. relying on a careful allowlist) has no escape hatch. The opt-out exists for that case.
+- **Default = force, opt-out via config** *(chosen)*. Prioritises the plugin's core promise; lets advanced users disable when they understand the trade-off.
+
+## Consequences
+
+- A user who installs the plugin while running Claude Code in `--dangerously-skip-permissions` (or equivalent bypass) will start seeing prompts they previously avoided. This is intended: the plugin's preview only works if there's a gate to hold open. README and `:CodePreviewStatus` should make the override discoverable.
+- Other agents (OpenCode, Codex, Copilot CLI) are not affected — their gate mechanism is owned by the agent itself, not by output the plugin emits.
+- If a new agent is added where the plugin can choose between forcing and deferring (analogous to Claude Code), this ADR sets the precedent: default to forcing.

--- a/docs/adr/0003-inline-renderer-as-future-default.md
+++ b/docs/adr/0003-inline-renderer-as-future-default.md
@@ -1,0 +1,19 @@
+# The inline renderer is the strategic direction; side-by-side is legacy
+
+The plugin has two preview [renderers](../../CONTEXT.md#renderer). The inline renderer is where new rendering features land; the side-by-side renderer is retained for users who depend on it but is no longer being invested in. The default [layout](../../CONTEXT.md#layout) (`"tab"`) still uses side-by-side today — flipping the default to `"inline"` is a future migration, not a current one.
+
+The reason: inline already does things side-by-side cannot reasonably do — character-level highlights, `]c`/`[c` navigation inside the diff buffer, a custom statuscolumn showing old|new line numbers — and it occupies a single window, which fits better with the rest of a typical Neovim workflow (file tree, terminal, sidebar). Side-by-side relies on Neovim's built-in `:diffthis`, which is robust but offers no extension surface for plugin-specific UX.
+
+## Considered Options
+
+- **Keep both as first-class peers indefinitely.** Rejected: doubles the surface that any future rendering work has to cover (extmark highlights, statuscolumn integration, keymaps). Two equally-maintained renderers is two backlogs.
+- **Delete the side-by-side renderer.** Rejected for now: users have `layout = "tab"` baked into their configs, and `:diffthis` is genuinely battle-tested. A hard removal would force a migration without a clean upgrade signal.
+- **Inline is the future, side-by-side is legacy** *(chosen)*. Side-by-side first reaches a *feature floor* with inline — anything inline can do that also makes sense for two side-by-side windows (e.g. character-level highlights) gets back-ported. After that point, no new direction-setting features land in side-by-side; it stays available, stable, and ungrowing.
+
+## Consequences
+
+- New direction-setting work (e.g. word-level highlight tuning, fold support, conflict-marker visualisation) lands in the inline path and is not back-ported to side-by-side. Feature-floor parity (the inline features that translate naturally to a two-window view, e.g. character-level highlights) *does* get back-ported once, then side-by-side is closed for further additions.
+- Bug fixes against the side-by-side renderer are still in scope — "legacy" means "no new direction," not "abandoned."
+- Items that don't translate to side-by-side at all (the custom statuscolumn with old|new line numbers, the inline-specific `]c`/`[c` keymaps that duplicate `:diffthis`'s built-ins) are *not* part of the feature floor and don't need ports.
+- A future ADR (or this one, superseded) will record the default flip. That decision needs at least: the inline renderer reaching feature parity for everything users actually rely on, and a deprecation window communicated in release notes.
+- The `lua/code-preview/diff.lua` split (referenced in the user's memory note) should respect this asymmetry: extract the inline renderer cleanly so it can grow, and let the side-by-side path stay as a thin wrapper around `:diffthis`.

--- a/docs/adr/0004-config-lives-only-in-neovim.md
+++ b/docs/adr/0004-config-lives-only-in-neovim.md
@@ -1,0 +1,18 @@
+# Config lives only in the running Neovim; the bash layer carries none of its own
+
+The plugin's config (`M.config` in `lua/code-preview/init.lua`) is the single source of truth. The bash [core handler](../../CONTEXT.md#core-handler) does not read user config files, environment variables, or a cached copy on disk — every config value it needs is fetched at hook time via a [hook context query](../../CONTEXT.md#hook-context-query) RPC into the running Neovim. If Neovim is unreachable, the bash handler degrades to a safe minimum (no logging, no [review gate](../../CONTEXT.md#review-gate), no visibility filtering) and proceeds.
+
+The reason: keeping a second copy of config on the bash side creates two ways to be wrong. The user changes `diff.visible_only` at runtime via `:CodePreviewToggleVisibleOnly`; a file-cached copy would have to be invalidated. The user reloads their `init.lua` and changes `defer_claude_permissions`; the cached file is now stale. RPC-on-demand sidesteps the entire cache-coherency problem at the cost of one round-trip per hook.
+
+## Considered Options
+
+- **Cache config in a JSON file under `stdpath('cache')`.** Rejected: requires invalidation on every config change (runtime toggle, `setup()` re-call, `:source` of init.lua), and the staleness window is silent — the bash side would happily make decisions on yesterday's config.
+- **Read config from environment variables exported at `setup()`.** Rejected: env vars only flow forward to processes spawned *after* the export. The bash handler is spawned by the agent, not by Neovim, so it inherits the agent's environment, not Neovim's.
+- **Query Neovim at hook time** *(chosen)*. Always reflects current config; trades one RPC round-trip for cache-coherency freedom.
+
+## Consequences
+
+- Per-hook latency includes at least one RPC round-trip (often two: `log.state` early + `hook_context` later). Acceptable today; if the cost ever bites, the two queries can be merged into one.
+- The bash handler's behaviour without Neovim is a real fallback path, not a bug — it must remain safe and silent. Tests should exercise the "no nvim" branch.
+- After issue #47 phases 3 and 4, the [core handler](../../CONTEXT.md#core-handler) runs as Lua via `nvim --headless -l`. The hook-context-query pattern still applies, but the call becomes an in-process function call rather than an RPC. The principle (config in Neovim, fetched on demand) does not change.
+- New config keys that the bash side might need must be added to `hook_context()`'s return shape — not silently exported to the environment or written to a side file.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,35 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+This is a single-context repo:
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-some-decision.md
+│   └── 0002-another-decision.md
+└── lua/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (some decision) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues in `Cannon07/code-preview`. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
## Summary

Baseline domain vocabulary and architectural decisions, established via a grilling session ahead of the bash-to-Lua migration in #47 phase 3. Pure documentation — no behaviour change.

- **`CONTEXT.md`** — 17 terms covering the full diff-preview pipeline: agent / integration, proposal / preview, RPC / socket discovery / pidfile, hook entry / core handler / dispatcher, change / status / origin prefix / indicator, tier 1 / tier 2, source/file/display path, visible-only mode / review gate, layout / renderer / reveal, hook context query, headless worker / in-process vs headless Lua.
- **`docs/adr/0001-origin-prefixed-status-values.md`** — Bash proposals are indicator-only, with origin-prefixed statuses. Records both the agent-behaviour observation (GPT-class models in Codex route edits through Bash) and the concurrency-safe prefix convention.
- **`docs/adr/0002-default-force-review-gate.md`** — Default to forcing the Claude Code review gate; opt-out via `defer_claude_permissions`.
- **`docs/adr/0003-inline-renderer-as-future-default.md`** — The inline renderer is the strategic direction; side-by-side reaches feature-floor parity then closes for further additions.
- **`docs/adr/0004-config-lives-only-in-neovim.md`** — Config lives only in the running Neovim; the bash layer queries on demand via hook context query.
- **`AGENTS.md` + `docs/agents/`** — pointers so future AI agent sessions discover the canonical issue tracker, triage labels, and domain doc layout.

## Why now

#47 phase 3 (port `core-pre-tool.sh` → `core-pre-tool.lua`) will reshape multiple modules. Doing it on a foundation of settled vocabulary makes the diff easier to review and the discussions easier to ground.

## Follow-ups

Refactor opportunities surfaced while preparing the baseline, tracked separately so they don't pollute either this PR or the phase 3 work:

- #55 — Path parameter rename in `show_diff` (source path / file path / display path)
- #56 — Char-level highlight parity for the side-by-side renderer
- #57 — Decouple neo-tree concerns from `diff.lua` (`mark_change_and_reveal`)
- #58 — Unify integration installer interface (`is_installed` / `install_state`)
- #59 — Remove deprecated `ClaudePreview*` command aliases
- #60 — Rename `/tmp/claude-diff-*` tempfiles to `/tmp/code-preview-*`
- #61 — Split `lua/code-preview/diff.lua` into focused modules

## Test plan

- [x] No code changed — verify CI still passes (docs-only diff).
- [x] `CONTEXT.md` cross-links resolve.
- [x] ADRs link correctly to `CONTEXT.md` and to each other where referenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)