### PR TITLE
fix: force UI flush after RPC-created diff on Windows conhost (cmd.exe)

### DIFF
--- a/lua/code-preview/diff.lua
+++ b/lua/code-preview/diff.lua
@@ -95,6 +95,31 @@ local function read_file_lines(path)
   return lines
 end
 
+-- Force the terminal to repaint after an RPC-driven tab/window change.
+--
+-- show_diff runs inside a `nvim --remote-expr` call from the hook shim, so the
+-- new diff tab exists in Neovim's state immediately but the TUI isn't repainted
+-- until the event loop next wakes. A deferred `redraw!` covers most hosts.
+--
+-- The Windows legacy console (cmd.exe / conhost) is the exception: it does NOT
+-- flush a timer-driven `redraw!` issued from an idle --remote-expr, so the diff
+-- only paints on the next event (the user's next edit) — neo-tree, which forces
+-- its own redraw, updates meanwhile, producing the "marking shows but diff
+-- doesn't" symptom. nvim__redraw({flush=true}) pushes the grid to the UI on the
+-- spot, and the <Ignore> feedkeys nudge wakes the input loop so conhost delivers
+-- it. Both are pcall'd: __redraw is 0.10+ and semi-private. The win32 guard keeps
+-- every other platform on the exact prior behaviour.
+local function force_redraw()
+  vim.fn.timer_start(10, function()
+    vim.cmd("redraw!")
+    if vim.fn.has("win32") == 1 then
+      pcall(vim.api.nvim__redraw, { flush = true })
+      pcall(vim.api.nvim_feedkeys,
+        vim.api.nvim_replace_termcodes("<Ignore>", true, false, true), "n", false)
+    end
+  end)
+end
+
 --- Count how many active diffs are currently open.
 local function active_count()
   local n = 0
@@ -412,8 +437,8 @@ function M.show_diff(original_path, proposed_path, real_file_path, abs_file_path
   if cfg.diff.layout == "inline" then
     local result = show_inline_diff(original_path, proposed_path, real_file_path, cfg)
     active_diffs[file_key] = result
-    -- Force terminal redraw via timer so RPC-triggered tab creation is visible
-    vim.fn.timer_start(10, function() vim.cmd("redraw!") end)
+    -- Force terminal redraw so RPC-triggered tab creation is visible (see force_redraw).
+    force_redraw()
     return
   end
 
@@ -498,7 +523,7 @@ function M.show_diff(original_path, proposed_path, real_file_path, abs_file_path
 
   vim.cmd("normal! ]c")
 
-  vim.fn.timer_start(10, function() vim.cmd("redraw!") end)
+  force_redraw()
 end
 
 --- Close the diff for a specific file and clean up its resources.


### PR DESCRIPTION
## Problem

On Windows, when Neovim runs inside the **legacy cmd.exe / conhost** console, an agent edit would mark the file in neo-tree **but the diff tab would not appear** until the *next* edit. Reproduced and root-caused with debug logs: the Lua pipeline (`show_diff` → `mark_change_and_reveal` → tab creation) runs identically on every edit — the diff tab **is** created in Neovim's state each time. The failure is purely a **screen flush**.

The diff is opened via the hook shim's `nvim --headless --server <pipe> --remote-expr …` call. The post-tab repaint relied on a single deferred `vim.cmd("redraw!")`. conhost does not flush that timer-driven redraw when it's triggered from an idle `--remote-expr`, so the grid is only pushed on the next event (the user's next edit). neo-tree updates meanwhile because it forces its *own* redraw — hence "marking shows, diff doesn't".

Confirmed terminal-dependent: **PowerShell terminal / Windows Terminal → fine; cmd.exe → broken.**

## Fix

Extract the repaint into a `force_redraw()` helper. On Windows only, after `redraw!`:
- `nvim__redraw({ flush = true })` — explicitly pushes the grid to the UI, and
- an `<Ignore>` `feedkeys` nudge — wakes the input loop so conhost delivers the flush immediately.

Both are `pcall`-wrapped (`nvim__redraw` is 0.10+ / semi-private), and the whole block is behind `vim.fn.has("win32")`, so **all other platforms keep byte-identical prior behaviour**. Applied to both the inline and side-by-side/tab paths in `show_diff`.

## Not a regression

This is **pre-existing Windows behaviour**, not introduced by the hook-entry consolidation (#77): the `timer_start(10, redraw!)` predates Windows support (since #37), and the RPC call path (`nvim-call.ps1`, `--headless`) was unchanged by that PR. This fix applies equally to the state already on `main`.

## Testing

- `require("code-preview.diff")` loads clean under headless nvim.
- `diff_lifecycle_spec.lua` results are **identical before/after** this change (verified via stash). Note: that spec currently has pre-existing failures on Windows (`config.diff` returns nil under `minimal_init.lua` — a separate Windows test-harness gap, unrelated to this change).
- **Manually verified in a cmd terminal**: the diff now appears on the **first** edit.

### Suggested manual checks for reviewers (in cmd.exe)
- Single Edit, Write (new file → virtual node), MultiEdit — all paint first try
- Multiple files edited in one turn (several diff tabs)
- Re-edit same file twice (close-then-reopen)
- Accept (post-tool close) and reject (`<leader>dq`) close cleanly
- PowerShell terminal still works (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)