### PR TITLE
Codex CLI on Windows: neo-tree markers, path handling, and shell-create detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 # Copilot CLI local hooks (installed by :CodePreviewInstallCopilotCliHooks)
 .github/hooks/code-preview.json
 
+# Codex CLI local hooks (installed by :CodePreviewInstallCodexCliHooks)
+.codex/
+
 # Test dependencies (plenary.nvim, installed by tests/run_lua.sh)
 deps/
 

--- a/lua/code-preview/apply/patch.lua
+++ b/lua/code-preview/apply/patch.lua
@@ -20,8 +20,17 @@
 
 local M = {}
 
+-- Detect already-absolute paths before joining with cwd. Besides a Unix "/",
+-- Codex emits Windows-absolute paths in apply_patch directives (a drive-letter
+-- `D:\proj\file` / `D:/proj/file`, or a UNC `\\server\share`). Without these
+-- checks such a path is treated as relative and doubled onto cwd
+-- (`D:\proj\D:\proj\file`), which then fs_stats as missing (so the file is
+-- mis-marked "created"), opens the diff at a bogus path, and injects a junk
+-- neo-tree node.
 local function resolve_path(path, cwd)
-  if path:sub(1, 1) == "/" then
+  if path:sub(1, 1) == "/"             -- Unix absolute
+    or path:match("^%a:[/\\]")         -- Windows drive-letter absolute
+    or path:sub(1, 2) == "\\\\" then   -- Windows UNC
     return path
   end
   return cwd .. "/" .. path

--- a/lua/code-preview/apply/patch.lua
+++ b/lua/code-preview/apply/patch.lua
@@ -197,4 +197,10 @@ function M.parse(patch_text, cwd)
   return results
 end
 
+-- Exposed so the PostToolUse handler resolves a patch's file path identically to
+-- the PreToolUse open path. A separate copy of this join in post_tool was what
+-- let the Windows-absolute doubling be fixed on open but not on close (the diff
+-- opened under the clean path but post tried to close a doubled one).
+M.resolve_path = resolve_path
+
 return M

--- a/lua/code-preview/changes.lua
+++ b/lua/code-preview/changes.lua
@@ -19,8 +19,11 @@ local function normalize(filepath)
   local p = vim.fn.fnamemodify(filepath, ":p")
   if package.config:sub(1, 1) == "\\" then
     p = p:gsub("/", "\\")
+    return (p:gsub("\\$", ""))   -- Windows: separators folded above; strip trailing "\"
   end
-  return (p:gsub("[/\\]$", ""))
+  -- Unix: byte-identical to the pre-Windows behaviour. Strip "/" only — a
+  -- trailing backslash is a legal Unix filename character, not a separator.
+  return (p:gsub("/$", ""))
 end
 
 function M.set(filepath, status)

--- a/lua/code-preview/changes.lua
+++ b/lua/code-preview/changes.lua
@@ -4,10 +4,23 @@ local M = {}
 -- Pure Lua key-value store, no external dependencies
 local pending = {}
 
--- Normalize path: make absolute and strip trailing slash
+-- Normalize path: make absolute, canonicalize separators, strip trailing slash.
+--
+-- Separator canonicalization is load-bearing on Windows: neo-tree keys its tree
+-- nodes by native (backslash) paths, and the BEFORE_RENDER handler looks our
+-- status up by `node.path`. Backends that build a file path by joining cwd with
+-- a relative patch/tool path (codex/opencode `apply_patch`, opencode/copilot
+-- Edit) produce mixed separators like `D:\proj\sub/file.txt`, which never
+-- compare equal to neo-tree's `D:\proj\sub\file.txt` — so the diff opens but the
+-- tree marker is silently dropped. Folding to the OS-native separator makes the
+-- registry key match. No-op on Unix (sep is "/"), and a no-op for the already
+-- native backslash paths Claude Code sends.
 local function normalize(filepath)
   local p = vim.fn.fnamemodify(filepath, ":p")
-  return (p:gsub("/$", ""))
+  if package.config:sub(1, 1) == "\\" then
+    p = p:gsub("/", "\\")
+  end
+  return (p:gsub("[/\\]$", ""))
 end
 
 function M.set(filepath, status)

--- a/lua/code-preview/health.lua
+++ b/lua/code-preview/health.lua
@@ -172,12 +172,10 @@ function M.check()
     warn("codex not found in PATH (install from https://github.com/openai/codex)")
   end
 
-  -- Codex now uses the shared bin/hook-entry shim (checked above); no
-  -- per-backend adapter script remains. Codex-on-Windows is wired but not yet
-  -- validated end-to-end (issue #46).
-  if is_win then
-    warn("Codex CLI on Windows is not yet validated (issue #46); use Claude Code on Windows")
-  end
+  -- Codex uses the shared bin/hook-entry shim (checked above); no per-backend
+  -- adapter script remains. Codex is supported on Windows (validated end-to-end,
+  -- issue #46) — its PowerShell shim path is the same one Claude Code uses, so
+  -- no Windows-specific warning is needed here.
 
   local codex_backend = require("code-preview.backends.codex")
   if codex_backend.is_installed() then

--- a/lua/code-preview/neo_tree.lua
+++ b/lua/code-preview/neo_tree.lua
@@ -51,9 +51,13 @@ local function resolve_status(lookup, node_path)
   if status then
     return status
   end
-  -- Check if any ancestor directory is marked as deleted
+  -- Check if any ancestor directory is marked as deleted. Use the OS-native
+  -- separator: registry keys are canonicalized to native separators (see
+  -- changes.normalize), and on Windows neo-tree's node_path is backslashed, so a
+  -- hardcoded "/" here would never match.
+  local sep = package.config:sub(1, 1)
   for path, s in pairs(lookup) do
-    if s == "deleted" and vim.startswith(node_path, path .. "/") then
+    if s == "deleted" and vim.startswith(node_path, path .. sep) then
       return "deleted"
     end
   end

--- a/lua/code-preview/post_tool.lua
+++ b/lua/code-preview/post_tool.lua
@@ -16,6 +16,7 @@ local changes     = require("code-preview.changes")
 local neo_tree    = require("code-preview.neo_tree")
 local diff        = require("code-preview.diff")
 local log         = require("code-preview.log")
+local apply_patch = require("code-preview.apply.patch")
 
 -- Extract paths from both unified-diff (+++ lines) and custom-patch
 -- (*** Update/Add/Delete File:) formats.
@@ -36,14 +37,13 @@ local function patch_paths(patch_text, cwd)
       table.insert(paths, (custom:gsub("%s+$", "")))
     end
   end
-  -- Resolve relative paths against cwd.
+  -- Resolve relative paths against cwd. Reuse apply.patch.resolve_path so the
+  -- close path matches the open path exactly — including Windows-absolute
+  -- handling (a private copy here is what previously doubled cwd onto an
+  -- already-absolute path, so close never matched the open diff).
   local out = {}
   for _, p in ipairs(paths) do
-    if p:sub(1, 1) ~= "/" and cwd and cwd ~= "" then
-      table.insert(out, cwd .. "/" .. p)
-    else
-      table.insert(out, p)
-    end
+    table.insert(out, apply_patch.resolve_path(p, cwd or ""))
   end
   return out
 end

--- a/lua/code-preview/pre_tool/init.lua
+++ b/lua/code-preview/pre_tool/init.lua
@@ -119,6 +119,29 @@ end
 
 -- ── Per-tool handlers ───────────────────────────────────────────
 
+-- Label shown on the diff tab: the file path relative to the agent's cwd, or the
+-- absolute path when the file isn't under cwd. The prefix test is
+-- separator-insensitive so a backslashed Windows file_path still matches a
+-- (possibly forward-slashed) cwd prefix — otherwise the relative-ization
+-- silently fails on Windows and the tab falls back to the full absolute path.
+-- The relative result is sliced from the ORIGINAL file_path, so it keeps its
+-- native separators. Byte-identical on Unix, where the fold is skipped (a
+-- backslash is a legal Unix filename character, not a separator).
+local function display_path(file_path, cwd)
+  if not cwd or cwd == "" then return file_path end
+  local n = #cwd
+  local fp, cw = file_path, cwd
+  if package.config:sub(1, 1) == "\\" then
+    fp = fp:gsub("\\", "/")
+    cw = cw:gsub("\\", "/")
+  end
+  if fp:sub(1, n + 1) == cw .. "/" then
+    return file_path:sub(n + 2)
+  end
+  return file_path
+end
+M.display_path = display_path  -- exposed for testing
+
 -- Compute the orig/proposed tempfile pair for a single-file tool and hand off
 -- to diff.show_diff (or skip when visible_only excludes the file). The only
 -- per-tool variation is how `proposed_content` is computed, so each handler
@@ -136,11 +159,7 @@ local function present_single_file(file_path, proposed_content, input, cfg)
     return
   end
 
-  local display = file_path
-  if input.cwd and file_path:sub(1, #input.cwd + 1) == input.cwd .. "/" then
-    display = file_path:sub(#input.cwd + 2)
-  end
-  diff.show_diff(orig, prop, display, file_path, nil)
+  diff.show_diff(orig, prop, display_path(file_path, input.cwd), file_path, nil)
 end
 
 local function handle_edit(input, cfg)

--- a/lua/code-preview/pre_tool/init.lua
+++ b/lua/code-preview/pre_tool/init.lua
@@ -246,7 +246,11 @@ local function handle_apply_patch(input, cfg)
 
     if should_show(cfg, file.path) then
       log.info(log.fmt("pre_tool: ApplyPatch send %s action=%s", file.rel_path, file.action))
-      diff.show_diff(orig, prop, file.rel_path, file.path, file.action)
+      -- Label from the resolved absolute path, not file.rel_path: rel_path is
+      -- whatever the model wrote in the `*** Update File:` directive, and some
+      -- codex models (e.g. GPT 5.3) write an absolute path there, which would
+      -- render the tab as `D:\...` instead of a cwd-relative label.
+      diff.show_diff(orig, prop, display_path(file.path, input.cwd), file.path, file.action)
     else
       log.info(log.fmt("pre_tool: ApplyPatch skip %s (visible_only)", file.rel_path))
     end

--- a/lua/code-preview/pre_tool/shell_detect.lua
+++ b/lua/code-preview/pre_tool/shell_detect.lua
@@ -599,6 +599,16 @@ local PS_MOVE = {
 local PS_COPY = {
   ["copy-item"] = true, cpi = true, copy = true,
 }
+-- New-Item creates a filesystem entry. `-ItemType File` (and other non-directory
+-- types) makes a new file — codex/GPT routinely creates files this way — so we
+-- treat it as a write and the brand-new path lands as `bash_created`, mirroring
+-- how Out-File / Set-Content already mark a write to a not-yet-existing file.
+-- `-ItemType Directory` is mkdir and is deliberately NOT flagged (parity with
+-- POSIX mkdir/touch staying unhandled, and the locked spec row
+-- `New-Item -ItemType Directory … | Out-Null → {}`). Handled in detect_ps.
+local PS_CREATE = {
+  ["new-item"] = true, ni = true,
+}
 
 -- Pull the path value(s) for a category out of parsed args. `named_keys` lists
 -- the value-params to check in priority order; `pos_index` is the positional
@@ -621,6 +631,7 @@ local function detect_ps(subcmd)
   local category
   if PS_DELETE[key] then category = "delete"
   elseif PS_WRITE[key] then category = "write"
+  elseif PS_CREATE[key] then category = "create"
   elseif PS_MOVE[key] then category = "move"
   elseif PS_COPY[key] then category = "copy"
   else return {}, {} end
@@ -644,6 +655,14 @@ local function detect_ps(subcmd)
   elseif category == "write" then
     -- Out-File uses -FilePath; Set/Add-Content use -Path; positional 1 either way.
     write_raw = ps_targets(named, positional, { "path", "literalpath", "filepath" }, 1)
+  elseif category == "create" then
+    -- New-Item: flag file creation, skip directory creation (mkdir). The path is
+    -- -Path/-LiteralPath or positional 1. itemtype is unquoted before the check
+    -- so `-ItemType "Directory"` is also recognised.
+    local itemtype = (named["itemtype"] or ""):gsub('["\']', ""):lower()
+    if itemtype ~= "directory" then
+      write_raw = ps_targets(named, positional, { "path", "literalpath" }, 1)
+    end
   else -- move / copy → the destination is the write target
     write_raw = ps_targets(named, positional, { "destination", "newname" }, 2)
   end

--- a/tests/plugin/apply_patch_spec.lua
+++ b/tests/plugin/apply_patch_spec.lua
@@ -1,0 +1,50 @@
+-- apply_patch_spec.lua — path resolution for the GPT/Codex patch format.
+
+local patch = require("code-preview.apply.patch")
+
+local function update_patch(p)
+  return "*** Begin Patch\n*** Update File: " .. p .. "\n@@\n-old\n+new\n*** End Patch\n"
+end
+
+-- Resolve the absolute path the parser assigns to the (single) file in a patch.
+local function resolved_path(file_path, cwd)
+  local files = patch.parse(update_patch(file_path), cwd)
+  return files[1].path
+end
+
+describe("apply_patch path resolution", function()
+  it("joins a relative path onto cwd", function()
+    assert.equals("/home/u/app/lua/init.lua", resolved_path("lua/init.lua", "/home/u/app"))
+  end)
+
+  it("passes a Unix-absolute path through unchanged", function()
+    assert.equals("/etc/hosts", resolved_path("/etc/hosts", "/home/u/app"))
+  end)
+
+  -- Regression: Codex emits Windows-absolute paths in apply_patch directives
+  -- (`*** Update File: D:\proj\file`). Treating those as relative doubled them
+  -- onto cwd (`D:\proj\D:\proj\file`), which fs_stats as missing — so an
+  -- existing file was mis-marked "created", the diff opened at a bogus path,
+  -- and a junk neo-tree node was injected. Absolute paths must pass through
+  -- unchanged. Cross-platform: the drive-letter check matches on Unix too.
+  it("passes a Windows drive-letter path through unchanged (backslash)", function()
+    assert.equals(
+      [[D:\proj\sub\file.txt]],
+      resolved_path([[D:\proj\sub\file.txt]], [[D:\proj]])
+    )
+  end)
+
+  it("passes a Windows drive-letter path through unchanged (forward slash)", function()
+    assert.equals(
+      "D:/proj/sub/file.txt",
+      resolved_path("D:/proj/sub/file.txt", [[D:\proj]])
+    )
+  end)
+
+  it("passes a Windows UNC path through unchanged", function()
+    assert.equals(
+      [[\\server\share\file.txt]],
+      resolved_path([[\\server\share\file.txt]], [[D:\proj]])
+    )
+  end)
+end)

--- a/tests/plugin/changes_registry_spec.lua
+++ b/tests/plugin/changes_registry_spec.lua
@@ -47,4 +47,26 @@ describe("changes registry", function()
     changes.set("/tmp/y.lua", "created")
     assert.equals(2, vim.tbl_count(changes.get_all()))
   end)
+
+  -- Regression: codex/opencode apply_patch build a file path by joining a
+  -- backslashed cwd with a forward-slashed relative path, so on Windows the
+  -- path arrives with mixed separators (D:\proj\sub/file.txt). The registry
+  -- must fold to the OS-native separator, otherwise the key never matches
+  -- neo-tree's native-backslash node.path and the tree marker is silently
+  -- dropped (the diff still opens). Asserted only on Windows: on Unix a
+  -- backslash is a valid filename character, not a separator, so there is no
+  -- mixed-separator case to canonicalize.
+  it("canonicalizes mixed path separators to native (Windows)", function()
+    if package.config:sub(1, 1) ~= "\\" then
+      return -- separator canonicalization only applies on Windows
+    end
+    changes.set([[D:\proj\sub/file.txt]], "modified")
+
+    local all = changes.get_all()
+    local key = next(all)
+    assert.equals("modified", all[key])
+    assert.is_nil(key:find("/", 1, true)) -- stored key has no forward slashes
+    -- a fully-native lookup (what neo-tree passes) hits the same entry
+    assert.equals("modified", changes.get([[D:\proj\sub\file.txt]]))
+  end)
 end)

--- a/tests/plugin/display_path_spec.lua
+++ b/tests/plugin/display_path_spec.lua
@@ -1,0 +1,39 @@
+-- display_path_spec.lua — diff-tab label: cwd-relative, separator-insensitive.
+
+local pre_tool = require("code-preview.pre_tool")
+local display_path = pre_tool.display_path
+
+describe("pre_tool.display_path", function()
+  it("strips the cwd prefix to a relative label", function()
+    assert.equals("sub/file.lua", display_path("/home/u/app/sub/file.lua", "/home/u/app"))
+  end)
+
+  it("keeps the absolute path when the file is not under cwd", function()
+    assert.equals("/etc/hosts", display_path("/etc/hosts", "/home/u/app"))
+  end)
+
+  it("returns the path unchanged when cwd is empty/nil", function()
+    assert.equals("/a/b.lua", display_path("/a/b.lua", ""))
+    assert.equals("/a/b.lua", display_path("/a/b.lua", nil))
+  end)
+
+  -- Regression: on Windows file_path is backslashed but cwd was compared as
+  -- `cwd .. "/"`, so the prefix never matched and the tab fell back to the full
+  -- absolute path. The fold makes the prefix test separator-insensitive; the
+  -- sliced result keeps native separators. Windows-gated: on Unix a backslash is
+  -- a legal filename character, so the fold must not run there.
+  it("strips a backslashed cwd prefix on Windows", function()
+    if package.config:sub(1, 1) ~= "\\" then
+      return -- Windows-only behaviour
+    end
+    assert.equals(
+      [[sub\file.lua]],
+      display_path([[D:\proj\sub\file.lua]], [[D:\proj]])
+    )
+    -- not under cwd → unchanged
+    assert.equals(
+      [[E:\other\file.lua]],
+      display_path([[E:\other\file.lua]], [[D:\proj]])
+    )
+  end)
+end)

--- a/tests/plugin/display_path_spec.lua
+++ b/tests/plugin/display_path_spec.lua
@@ -37,3 +37,31 @@ describe("pre_tool.display_path", function()
     )
   end)
 end)
+
+describe("pre_tool.handle ApplyPatch label", function()
+  -- Regression: handle_apply_patch labelled the diff tab with file.rel_path —
+  -- the literal path from the `*** Update File:` directive. Some codex models
+  -- (GPT 5.3) write an ABSOLUTE path there, so the tab rendered `D:\...` instead
+  -- of a cwd-relative label. The label must derive from the resolved path via
+  -- display_path. Windows-gated: relativising a drive-letter path only happens
+  -- on Windows.
+  it("labels with a cwd-relative path even when the model emits an absolute path", function()
+    if package.config:sub(1, 1) ~= "\\" then
+      return -- Windows-only behaviour
+    end
+    local diff = require("code-preview.diff")
+    local changes = require("code-preview.changes")
+    local captured
+    local orig = diff.show_diff
+    diff.show_diff = function(_orig, _prop, display) captured = display end
+
+    local abs = [[D:\proj\sub\README.md]]
+    local cmd = "*** Begin Patch\n*** Update File: " .. abs .. "\n@@\n-old\n+new\n*** End Patch\n"
+    pre_tool.handle({ tool_name = "apply_patch", cwd = [[D:\proj]], tool_input = { command = cmd } }, "codex")
+
+    diff.show_diff = orig
+    changes.clear_all()
+
+    assert.equals([[sub\README.md]], captured)
+  end)
+end)

--- a/tests/plugin/post_tool_handle_spec.lua
+++ b/tests/plugin/post_tool_handle_spec.lua
@@ -84,6 +84,34 @@ describe("post_tool.handle (ApplyPatch)", function()
 
     assert.are.same({ "/proj/a.txt", "/proj/b.txt" }, closed)
   end)
+
+  it("does not double cwd onto a Windows-absolute patch path", function()
+    -- Regression: post_tool used a private path resolver whose absolute check
+    -- was Unix-only, so a Windows-absolute `*** Update File:` path (codex sends
+    -- these for some projects) was joined onto cwd and doubled
+    -- (D:\proj\D:\proj\sub\README.md). The close path then no longer matched
+    -- the open diff, so the marker/diff never cleared after accept. post_tool
+    -- now shares apply.patch.resolve_path, so the absolute path passes through.
+    -- Cross-platform: the drive-letter check matches on Unix too.
+    local diff = require("code-preview.diff")
+    local closed = {}
+    local orig = diff.close_for_file
+    diff.close_for_file = function(p) table.insert(closed, p) end
+
+    local abs = [[D:\proj\sub\README.md]]
+    local patch = table.concat({
+      "*** Begin Patch",
+      "*** Update File: " .. abs,
+      "@@",
+      "-old",
+      "+new",
+      "*** End Patch",
+    }, "\n")
+    post_tool.handle(payload("ApplyPatch", { patch_text = patch }, [[D:\proj]]), "claudecode")
+    diff.close_for_file = orig
+
+    assert.are.same({ abs }, closed)
+  end)
 end)
 
 describe("post_tool.handle (robustness)", function()

--- a/tests/plugin/pre_tool_shell_detect_spec.lua
+++ b/tests/plugin/pre_tool_shell_detect_spec.lua
@@ -183,8 +183,14 @@ describe("shell_detect.detect_write_paths (Windows)", function()
     { name = "Copy-Item destination",       cmd = [[Copy-Item -Path ".step0\a" -Destination ".step0\c.txt" -Force]], expect = { [[C:\proj\.step0\c.txt]] } },
     { name = "Move-Item windows-abs dest",  cmd = [[Move-Item -Path "a" -Destination "D:\dst\b.txt"]], expect = { [[D:\dst\b.txt]] } },
     { name = "UNC destination",             cmd = [[Set-Content -Path "\\srv\share\f.txt" -Value x]], expect = { [[\\srv\share\f.txt]] } },
+    -- New-Item file creation → flagged as a write (becomes bash_created downstream).
+    { name = "New-Item -ItemType File -Path", cmd = [[New-Item -ItemType File -Path 'temp1.txt' -Force]], expect = { [[C:\proj\temp1.txt]] } },
+    { name = "New-Item File positional",    cmd = [[New-Item "bare.txt" -ItemType File]], expect = { [[C:\proj\bare.txt]] } },
+    { name = "ni alias File",               cmd = [[ni -ItemType File -Path "sub\made.txt"]], expect = { [[C:\proj\sub\made.txt]] } },
+    { name = "New-Item two files ;|Out-Null", cmd = [[New-Item -ItemType File -Path 'temp1.txt' -Force | Out-Null; New-Item -ItemType File -Path 'shareApplication\temp2.txt' -Force | Out-Null]], expect = { [[C:\proj\temp1.txt]], [[C:\proj\shareApplication\temp2.txt]] } },
     -- Look-alikes that must NOT be flagged as writes.
     { name = "Out-Null not a write",        cmd = [[New-Item -ItemType Directory d | Out-Null]], expect = {} },
+    { name = "New-Item Directory not a write", cmd = [[New-Item -ItemType Directory -Path "newdir"]], expect = {} },
     { name = "Out-String not a write",      cmd = [[Get-Process | Out-String]],         expect = {} },
     { name = "transient .tmp filtered",     cmd = [[Set-Content -Path "scratch.tmp" -Value x]], expect = {} },
     { name = "FD redirect skipped",         cmd = [[some-exe 2>&1]],                     expect = {} },


### PR DESCRIPTION
## Summary

Makes the **Codex CLI backend work correctly on Windows** (validated end-to-end with `codex-cli 0.137`, GPT 5.5 and GPT 5.3). The integration was already wired for Windows; this PR fixes the Windows-specific path/marker bugs that surfaced under real use, plus a couple of related quality/consistency fixes. Claude Code on Windows is unaffected, and Unix behaviour is preserved (see *Unix safety* below).

## What was broken & fixed

### 1. neo-tree markers silently dropped (path separators)
Codex routes edits through `apply_patch` with relative paths; `apply/patch.lua` joined them as `cwd .. "/" .. relpath`, and on Windows `cwd` is backslashed → a mixed-separator key (`D:\proj\sub/file.txt`). neo-tree keys nodes by native backslash paths, so the lookup missed and **no created/modified/deleted marker rendered** (the diff still opened). Claude Code was immune (it sends native paths).
- `changes.lua` — `normalize()` folds separators to the OS-native one on Windows (central key canonicalization).
- `neo_tree.lua` — the ancestor-deletion check used a hardcoded `"/"`; now uses the native separator.

### 2. Existing file shown as "new file" (absolute-path doubling — open)
For some projects Codex emits **absolute** paths in `apply_patch` directives (`*** Update File: D:\proj\sub\file`). `resolve_path` only treated a leading `/` as absolute, so a Windows-absolute path was doubled onto cwd (`D:\proj/D:\proj\sub\file`). That bogus path `fs_stat`s as missing → file mis-marked `created`, diff opened at the wrong position (rendered as a new file), and a junk neo-tree node appeared.
- `apply/patch.lua` — `resolve_path` now recognizes Windows drive-letter (`X:\`/`X:/`) and UNC (`\`) absolutes and passes them through.

### 3. PostToolUse didn't clear the diff/marker after accept (open/close parity)
`post_tool.lua` had its *own* copy of the path-join with the same Unix-only absolute check, so the **close** path was still doubled while the **open** path was fixed → `close_for_file: no active diff … skipping` → marker/diff never cleared.
- `post_tool.lua` — now reuses `apply.patch.resolve_path` (exported), so open and close resolve identically and can't diverge again.

### 4. Diff-tab label showed the absolute path
On Windows the cwd-prefix strip compared `D:\proj\…` against `D:\proj/` (forward slash) and never matched, so the tab title fell back to the full absolute path. Additionally, `apply_patch` labelled the tab with `file.rel_path` — the literal directive path — which GPT 5.3 writes as **absolute**.
- `pre_tool/init.lua` — extracted `display_path()` with a separator-insensitive cwd-prefix test (relative result keeps native separators); used for Edit/Write **and** apply_patch, so the label is cwd-relative regardless of OS or what the model emits.

### 5. `New-Item` file creation not detected (shell-create)
Codex/GPT creates files on Windows via PowerShell `New-Item -ItemType File`, which the shell-detect grammar didn't recognize → no neo-tree mark.
- `shell_detect.lua` — added `new-item`/`ni` as a create category routed through the existing write path (a brand-new file becomes `bash_created`, like `Out-File` to a new file). `-ItemType Directory` is deliberately skipped (parity with `mkdir` and the locked `New-Item -ItemType Directory … | Out-Null → {}` spec row); POSIX `touch` is left untouched.

### 6. Healthcheck no longer steers Codex users away
- `health.lua` — removed the stale Windows-only warning *"Codex CLI on Windows is not yet validated … use Claude Code on Windows"* now that Codex is supported on Windows. (Copilot-on-Windows remains correctly deferred.)

### 7. Housekeeping
- `.gitignore` — ignore `.codex/` (local hook install written by `:CodePreviewInstallCodexCliHooks`), matching the existing opencode/copilot entries.

## Unix safety

Windows path transforms are either gated on `package.config:sub(1,1) == "\\"` (`changes.normalize`, `display_path`) or use the native separator `package.config:sub(1,1)` (`neo_tree`), so the Unix paths are **byte-identical** to before. The `resolve_path` absolute-detection and the `New-Item` grammar are not OS-gated but only match Windows-shaped input (`X:\` paths / a PowerShell cmdlet) that doesn't occur in real Unix workflows. No Unix workflow changes.

## Tests

Regression specs added/extended:
- `changes_registry_spec` — mixed-separator key canonicalization (Windows-gated)
- `apply_patch_spec` — relative / Unix-absolute / Windows-absolute / UNC resolution (cross-platform)
- `post_tool_handle_spec` — Windows-absolute patch path not doubled on close
- `display_path_spec` — separator-insensitive label + an integration test driving `pre_tool.handle` with an absolute-path codex patch
- `pre_tool_shell_detect_spec` — `New-Item` file create (incl. the exact `; … | Out-Null` two-file command), `ni` alias, and directory-create still `{}`

Full plugin spec suite passes on Windows (per-file; `PlenaryBustedDirectory` hangs headless on Windows). `diff_lifecycle_spec` fails 13/14 headless on Windows on `origin/main` too — a pre-existing UI limitation, not introduced here.

Validated end-to-end on Windows 11 with `codex-cli 0.137` (GPT 5.5 / 5.3) and Claude Code: `apply_patch` (relative & absolute) and PowerShell shell ops mark correctly, open the diff at the right position with a relative tab label, and clear on accept.

Relates to #46.