### PR TITLE
fix: validate diff layout, fall back to tab on unknown value

### DIFF
--- a/lua/code-preview/diff.lua
+++ b/lua/code-preview/diff.lua
@@ -127,15 +127,35 @@ local function active_count()
   return n
 end
 
+local VALID_LAYOUTS = { tab = true, vsplit = true, inline = true }
+
+-- Values we've already warned about, so a misconfigured layout warns once
+-- rather than on every diff (log.warn surfaces via vim.notify).
+local warned_layouts = {}
+
+-- Validate a resolved layout. An unknown value (a typo like "vspllit", or a
+-- layout removed in a future version) otherwise falls through to the "tabnew"
+-- branch silently, making the config look ignored. Warn once and fall back to
+-- the supported default.
+local function valid_layout(layout)
+  if VALID_LAYOUTS[layout] then return layout end
+  if layout and not warned_layouts[layout] then
+    warned_layouts[layout] = true
+    log.warn(log.fmt(
+      'unknown diff layout %q; falling back to "tab" (valid: tab, vsplit, inline)', layout))
+  end
+  return "tab"
+end
+
 local function layout_for_backend(cfg, backend)
   local diff_cfg = (cfg and cfg.diff) or {}
   local layouts = diff_cfg.layouts or {}
 
   if backend and layouts[backend] then
-    return layouts[backend]
+    return valid_layout(layouts[backend])
   end
 
-  return diff_cfg.layout or "tab"
+  return valid_layout(diff_cfg.layout or "tab")
 end
 
 function M.is_open(file_path)

--- a/tests/plugin/diff_lifecycle_spec.lua
+++ b/tests/plugin/diff_lifecycle_spec.lua
@@ -333,4 +333,44 @@ describe("diff layouts", function()
     os.remove(orig)
     os.remove(prop)
   end)
+
+  it("an unknown layout value falls back to the default tab layout", function()
+    local orig = tmp_file("bad_layout_orig.txt", "alpha\nbeta")
+    local prop = tmp_file("bad_layout_prop.txt", "alpha\ngamma")
+
+    local tabs_before = #vim.api.nvim_list_tabpages()
+
+    -- A typo'd layout must not silently behave like vsplit/inline; it warns
+    -- (once) and falls back to a new tab.
+    with_layout("vspllit", function()
+      diff.show_diff(orig, prop, "layout_bad_value.txt")
+    end)
+
+    assert.is_true(diff.is_open())
+    assert.equals(tabs_before + 1, #vim.api.nvim_list_tabpages())
+    local diff_tabpage = vim.api.nvim_get_current_tabpage()
+    assert.equals(2, #vim.api.nvim_tabpage_list_wins(diff_tabpage))
+
+    diff.close_diff()
+    os.remove(orig)
+    os.remove(prop)
+  end)
+
+  it("an unknown per-backend layout override falls back to tab", function()
+    local orig = tmp_file("bad_backend_orig.txt", "alpha\nbeta")
+    local prop = tmp_file("bad_backend_prop.txt", "alpha\ngamma")
+
+    local tabs_before = #vim.api.nvim_list_tabpages()
+
+    with_layout("tab", function()
+      diff.show_diff(orig, prop, "layout_bad_backend.txt", nil, nil, "codex")
+    end, { codex = "vspllit" })
+
+    assert.is_true(diff.is_open())
+    assert.equals(tabs_before + 1, #vim.api.nvim_list_tabpages())
+
+    diff.close_diff()
+    os.remove(orig)
+    os.remove(prop)
+  end)
 end)


### PR DESCRIPTION
## Summary

Validates the resolved diff layout and falls back to `tab` on an unknown value, instead of silently rendering as a tab with no feedback.

An unknown layout — a typo (`"vspllit"`) or a layout removed in a future version — previously fell through to the `tabnew` branch silently, so a misconfigured `diff.layout` / `diff.layouts` looked ignored. Pre-existing gap surfaced during the #82 review (the per-backend `layouts` map widened the surface).

## Changes

- **`diff.lua`** — `valid_layout()` check inside the `layout_for_backend` resolution chokepoint, covering both `diff.layout` and the per-backend `diff.layouts` overrides in one place. Warns **once per bad value** (via a `warned_layouts` guard) and falls back to `"tab"` — the once-guard matters because `log.warn` fires a user-visible `vim.notify`, which would otherwise pop on every diff.
- **`tests/`** — two specs: unknown default layout → tab, unknown per-backend override → tab.

## Testing

- Full Lua suite green on macOS (178 passed). New tests cover both validation branches.
- Pure Lua / OS-independent; no path or PowerShell handling involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)